### PR TITLE
Remove whitespace from RSS links

### DIFF
--- a/nyaa/templates/rss.xml
+++ b/nyaa/templates/rss.xml
@@ -10,9 +10,7 @@
 		{% if torrent.has_torrent %}
 		<item>
 			<title>{{ torrent.display_name }}</title>
-			<link>
-				{{ url_for('download_torrent', torrent_id=torrent.id, _external=True) }}
-			</link>
+			<link>{{ url_for('download_torrent', torrent_id=torrent.id, _external=True) }}</link>
 			<guid isPermaLink="true">{{ url_for('view_torrent', torrent_id=torrent.id, _external=True) }}</guid>
 			<pubDate>{{ torrent.created_time|rfc822 }}</pubDate>
 		</item>

--- a/nyaa/templates/rss.xml
+++ b/nyaa/templates/rss.xml
@@ -1,9 +1,7 @@
 <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
 	<channel>
 		<title>{{ config.SITE_NAME }} Torrent File RSS (No magnets)</title>
-		<description>
-			RSS Feed for {{ term }}
-		</description>
+		<description>RSS Feed for {{ term }}</description>
 		<link>{{ url_for('home', _external=True) }}</link>
 		<atom:link href="{{ url_for('home', page='rss', _external=True) }}" rel="self" type="application/rss+xml" />
 		{% for torrent in query %}


### PR DESCRIPTION
Might cause issues for applications with an XML parser that considers leading and trailing whitespace characters as significant. Encountered and fixed this issue in my application, sending this PR in case it affects others.