### PR TITLE
Small CSS tweaks to the torrent listing and torrent view on mobile

### DIFF
--- a/nyaa/static/css/main.css
+++ b/nyaa/static/css/main.css
@@ -83,3 +83,9 @@ table.torrent-list thead th.sorting_desc:after {
 .panel-deleted > .panel-footer + .panel-collapse > .panel-body {
 	border-bottom-color:#757575;
 }
+@media (max-width: 991px){
+	.col-md-5 {
+	    margin-left: 20px;
+	    margin-bottom: 10px;
+	}
+}

--- a/nyaa/static/css/main.css
+++ b/nyaa/static/css/main.css
@@ -89,3 +89,6 @@ table.torrent-list thead th.sorting_desc:after {
 	    margin-bottom: 10px;
 	}
 }
+.table-striped>tbody>tr:nth-of-type(odd) {
+    background-color: white;
+}


### PR DESCRIPTION
Made it so that the torrent info is a bit easier to read on the compact version.

- [Mobile before](http://i.imgur.com/L6TyR3h.png)    
- [Mobile after](http://i.imgur.com/euutdTJ.png)

Also removed the slightly gray background on odd numbered torrents on the list.