### PR TITLE
Make upload form input label less ambiguous.

### DIFF
--- a/nyaa/forms.py
+++ b/nyaa/forms.py
@@ -169,7 +169,7 @@ class UploadForm(FlaskForm):
         FileRequired()
     ])
 
-    display_name = TextField('Display name (optional)', [
+    display_name = TextField('Torrent name (optional)', [
         Optional(),
         Length(min=3, max=255,
                message='Torrent name must be at least %(min)d characters long and %(max)d at most.')


### PR DESCRIPTION
Change "Display name" label in torrent upload form to "Torrent name", so as not to confuse the minority of users who think their username goes there.