### PR TITLE
Fix layout on long torrent names

### DIFF
--- a/nyaa/static/css/main.css
+++ b/nyaa/static/css/main.css
@@ -11,10 +11,10 @@
 
 .torrent-list > tbody > tr > td {
 	vertical-align: middle;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 603px;	/*Will this break something?*/
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 603px;	/*Will this break something?*/
 }
 
 table.torrent-list thead th {

--- a/nyaa/static/css/main.css
+++ b/nyaa/static/css/main.css
@@ -11,6 +11,10 @@
 
 .torrent-list > tbody > tr > td {
 	vertical-align: middle;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 603px;	/*Will this break something?*/
 }
 
 table.torrent-list thead th {


### PR DESCRIPTION
Please check if this breaks something

before: http://i.imgur.com/cI1pZrF.png
after: http://i.imgur.com/BIC722K.png