### PR TITLE
Revert c14649b because it "breaks" nightmode

### DIFF
--- a/nyaa/static/css/main.css
+++ b/nyaa/static/css/main.css
@@ -93,6 +93,3 @@ table.torrent-list thead th.sorting_desc:after {
 	    margin-bottom: 10px;
 	}
 }
-.table-striped>tbody>tr:nth-of-type(odd) {
-    background-color: white;
-}

--- a/nyaa/static/css/main.css
+++ b/nyaa/static/css/main.css
@@ -11,10 +11,10 @@
 
 .torrent-list > tbody > tr > td {
 	vertical-align: middle;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 603px;	/*Will this break something?*/
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 603px;	/*Will this break something?*/
 }
 
 table.torrent-list thead th {

--- a/nyaa/static/css/main.css
+++ b/nyaa/static/css/main.css
@@ -11,6 +11,10 @@
 
 .torrent-list > tbody > tr > td {
 	vertical-align: middle;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 603px;	/*Will this break something?*/
 }
 
 table.torrent-list thead th {


### PR DESCRIPTION
There does not seem to be a css class that marks the theme, so not sure how is the proper bootstrap way to fix this.

Also, the "remake" and "trusted" colors should be changed in nightmode as well, to a darker tone.

Current: http://i.imgur.com/hDNv7nf.png
After: http://i.imgur.com/upLHArx.png