### PR TITLE
Markdown preview

### DIFF
--- a/nyaa/static/css/main.css
+++ b/nyaa/static/css/main.css
@@ -87,6 +87,11 @@ table.torrent-list thead th.sorting_desc:after {
 .panel-deleted > .panel-footer + .panel-collapse > .panel-body {
 	border-bottom-color:#757575;
 }
+
+.markdown-editor label {
+	padding: 1em 0;
+}
+
 @media (max-width: 991px){
 	.col-md-5 {
 	    margin-left: 20px;

--- a/nyaa/static/js/main.js
+++ b/nyaa/static/js/main.js
@@ -77,6 +77,26 @@ document.addEventListener("DOMContentLoaded", function(event) {
 	};
 });
 
+// Initialise markdown editors on page
+document.addEventListener("DOMContentLoaded", function() {
+  var markdownEditors = Array.prototype.slice.call(document.querySelectorAll('.markdown-editor'));
+
+  markdownEditors.forEach(function (markdownEditor) {
+    var fieldName = markdownEditor.getAttribute('data-field-name');
+
+    var previewTabSelector = '#' + fieldName + '-preview-tab';
+    var targetSelector = '#' + fieldName + '-markdown-target';
+    var sourceSelector = markdownEditor.querySelector('.markdown-source');
+
+    var previewTabEl = markdownEditor.querySelector(previewTabSelector);
+    var targetEl = markdownEditor.querySelector(targetSelector);
+
+    previewTabEl.addEventListener('click', function () {
+      targetEl.innerHTML = marked(sourceSelector.value.trim());
+    });
+  });
+});
+
 // 
 // This is the unminified version of the theme changer script in the layout.html @ line: 21
 // ===========================================================

--- a/nyaa/templates/_formhelpers.html
+++ b/nyaa/templates/_formhelpers.html
@@ -31,20 +31,30 @@
 {% else %}
     <div class="form-group">
 {% endif %}
-    <div class="markdown-editor" id="{{ field_name }}-markdown-editor">
+    <div class="markdown-editor" id="{{ field_name }}-markdown-editor" data-field-name="{{ field_name }}">
         <ul class="nav nav-tabs" role="tablist">
-            <li role="presentation" class="active"><a href="#{{ field_name }}-tab" aria-controls="" role="tab" data-toggle="tab">Write</a></li>
-            <li role="presentation"><a href="#{{ field_name }}-preview" id="{{ field_name }}-preview-tab" aria-controls="preview" role="tab" data-toggle="tab">Preview</a></li>
+            <li role="presentation" class="active">
+                <a href="#{{ field_name }}-tab" aria-controls="" role="tab" data-toggle="tab">
+                    Write
+                </a>
+            </li>
+            <li role="presentation">
+                <a href="#{{ field_name }}-preview" id="{{ field_name }}-preview-tab" aria-controls="preview" role="tab" data-toggle="tab">
+                    Preview
+                </a>
+            </li>
         </ul>
         <div class="tab-content">
             <div role="tabpanel" class="tab-pane active" id="{{ field_name }}-tab" data-markdown-target="#{{ field_name }}-markdown-target">
                 {{ render_field(field, class_='form-control markdown-source') }}
             </div>
             <div role="tabpanel" class="tab-pane" id="{{ field_name }}-preview">
+                {{ field.label(class='control-label') }}
                 <div id="{{ field_name }}-markdown-target"></div>
             </div>
         </div>
     </div>
+</div>
 {% endmacro %}
 
 

--- a/nyaa/templates/_formhelpers.html
+++ b/nyaa/templates/_formhelpers.html
@@ -50,7 +50,7 @@
             </div>
             <div role="tabpanel" class="tab-pane" id="{{ field_name }}-preview">
                 {{ field.label(class='control-label') }}
-                <div id="{{ field_name }}-markdown-target"></div>
+                <div class="well" id="{{ field_name }}-markdown-target"></div>
             </div>
         </div>
     </div>

--- a/nyaa/templates/_formhelpers.html
+++ b/nyaa/templates/_formhelpers.html
@@ -24,6 +24,30 @@
 	</div>
 {% endmacro %}
 
+
+{% macro render_markdown_editor(field, field_name='') %}
+{% if field.errors %}
+    <div class="form-group has-error">
+{% else %}
+    <div class="form-group">
+{% endif %}
+    <div class="markdown-editor" id="{{ field_name }}-markdown-editor">
+        <ul class="nav nav-tabs" role="tablist">
+            <li role="presentation" class="active"><a href="#{{ field_name }}-tab" aria-controls="" role="tab" data-toggle="tab">Write</a></li>
+            <li role="presentation"><a href="#{{ field_name }}-preview" id="{{ field_name }}-preview-tab" aria-controls="preview" role="tab" data-toggle="tab">Preview</a></li>
+        </ul>
+        <div class="tab-content">
+            <div role="tabpanel" class="tab-pane active" id="{{ field_name }}-tab" data-markdown-target="#{{ field_name }}-markdown-target">
+                {{ render_field(field, class_='form-control markdown-source') }}
+            </div>
+            <div role="tabpanel" class="tab-pane" id="{{ field_name }}-preview">
+                <div id="{{ field_name }}-markdown-target"></div>
+            </div>
+        </div>
+    </div>
+{% endmacro %}
+
+
 {% macro render_upload(field) %}
 {% if field.errors %}
 	<div class="form-group has-error">

--- a/nyaa/templates/edit.html
+++ b/nyaa/templates/edit.html
@@ -2,6 +2,7 @@
 {% block title %}Edit {{ torrent.display_name }} :: {{ config.SITE_NAME }}{% endblock %}
 {% block body %}
 {% from "_formhelpers.html" import render_field %}
+{% from "_formhelpers.html" import render_markdown_editor %}
 
 <h1>Edit Torrent</h1>
 
@@ -28,7 +29,7 @@
 
 	<div class="row">
 		<div class="form-group col-md-6">
-			{{ render_field(form.description, class_='form-control') }}
+			{{ render_markdown_editor(form.description, field_name='description') }}
 		</div>
 	</div>
 

--- a/nyaa/templates/upload.html
+++ b/nyaa/templates/upload.html
@@ -38,11 +38,11 @@
 		</div>
 	</div>
 
-	<div class="row">
-		<div class="form-group col-md-6">
-			{{ render_field(form.description, class_='form-control') }}
-		</div>
-	</div>
+    <div class="row">
+        <div class="form-group col-md-6">
+            {{ render_markdown_editor(form.description, field_name='description') }}
+        </div>
+    </div>
 
 	<div class="row">
 		<div class="form-group col-md-6">

--- a/nyaa/templates/upload.html
+++ b/nyaa/templates/upload.html
@@ -3,6 +3,7 @@
 {% block body %}
 {% from "_formhelpers.html" import render_field %}
 {% from "_formhelpers.html" import render_upload %}
+{% from "_formhelpers.html" import render_markdown_editor %}
 
 <h1>Upload Torrent</h1>
 


### PR DESCRIPTION
In order to make the markdown editor fields reusable, I've added a `render_markdown_editor` macro that should automatically generate the relevant DOM structure which is utilised by the changes in `main.js`. To make sure that we can multiple markdown editors, you have to namespace them with the field's name.

Let me know you would like any further changes.