### PR TITLE
Update RSS template

### DIFF
--- a/nyaa/routes.py
+++ b/nyaa/routes.py
@@ -303,6 +303,7 @@ def render_rss(label, query, use_elastic):
                                     use_elastic=use_elastic,
                                     term=label,
                                     site_url=flask.request.url_root,
+                                    compute_hash=lambda x: base64.b32encode(x).decode('utf-8'),
                                     torrent_query=query)
     response = flask.make_response(rss_xml)
     response.headers['Content-Type'] = 'application/xml'

--- a/nyaa/templates/rss.xml
+++ b/nyaa/templates/rss.xml
@@ -5,33 +5,31 @@
 		<link>{{ url_for('home', _external=True) }}</link>
 		<atom:link href="{{ url_for('home', page='rss', _external=True) }}" rel="self" type="application/rss+xml" />
 		{% for torrent in torrent_query %}
-		{% if torrent.has_torrent %}
 		<item>
 			<title>{{ torrent.display_name }}</title>
+			<description>{{ torrent.description }}</description>
 			{% if use_elastic %}
-			<link>{{ url_for('download_torrent', torrent_id=torrent.meta.id, _external=True) }}</link>
-			<guid isPermaLink="true">{{ url_for('view_torrent', torrent_id=torrent.meta.id, _external=True) }}</guid>
-			<pubDate>{{ torrent.created_time|rfc822_es }}</pubDate>
+				{% if torrent.has_torrent %}
+				<link>{{ url_for('download_torrent', torrent_id=torrent.meta.id, _external=True) }}</link>
+				{% else %}
+				<link>{{ create_magnet_from_info(torrent.display_name, torrent.info_hash) }}</link>
+				{% endif %}
+				<guid isPermaLink="true">{{ url_for('view_torrent', torrent_id=torrent.meta.id, _external=True) }}</guid>
+				<pubDate>{{ torrent.created_time|rfc822_es }}</pubDate>
 			{% else %}
-			<link>{{ url_for('download_torrent', torrent_id=torrent.id, _external=True) }}</link>
-			<guid isPermaLink="true">{{ url_for('view_torrent', torrent_id=torrent.id, _external=True) }}</guid>
-			<pubDate>{{ torrent.created_time|rfc822 }}</pubDate>
-			{% endif %}			
-		</item>
-		{% else %}
-		<item>
-			<title>{{ torrent.display_name }}</title>
-			{% if use_elastic %}
-			<link>{{ create_magnet_from_info(torrent.display_name, torrent.info_hash) }}</link>
-			<guid isPermaLink="true">{{ url_for('view_torrent', torrent_id=torrent.meta.id, _external=True) }}</guid>
-			<pubDate>{{ torrent.created_time|rfc822_es }}</pubDate>
-			{% else %}
-			<link>{{ torrent.magnet_uri }}</link>
-			<guid isPermaLink="true">{{ url_for('view_torrent', torrent_id=torrent.id, _external=True) }}</guid>
-			<pubDate>{{ torrent.created_time|rfc822 }}</pubDate>
+				{% if torrent.has_torrent %}
+				<link>{{ url_for('download_torrent', torrent_id=torrent.id, _external=True) }}</link>
+				{% else %}
+				<link>{{ torrent.magnet_uri }}</link>
+				{% endif %}
+				<guid isPermaLink="true">{{ url_for('view_torrent', torrent_id=torrent.id, _external=True) }}</guid>
+				<pubDate>{{ torrent.created_time|rfc822 }}</pubDate>
 			{% endif %}
+			<size>{{ torrent.filesize }}</size>
+			<seeders>{{ torrent.stats.seed_count }}</seeders>
+			<leechers>{{ torrent.stats.leech_count }}</leechers>
+			<downloads>{{ torrent.stats.download_count }}</downloads>
 		</item>
-		{% endif %}
 		{% endfor %}
 	</channel>
 </rss>

--- a/nyaa/templates/rss.xml
+++ b/nyaa/templates/rss.xml
@@ -7,7 +7,7 @@
 		{% for torrent in torrent_query %}
 		<item>
 			<title>{{ torrent.display_name }}</title>
-			<description>{{ torrent.description }}</description>
+			<description><![CDATA[{{ torrent.description }}]]></description>
 			{% if use_elastic %}
 				{% if torrent.has_torrent %}
 				<link>{{ url_for('download_torrent', torrent_id=torrent.meta.id, _external=True) }}</link>

--- a/nyaa/templates/rss.xml
+++ b/nyaa/templates/rss.xml
@@ -25,6 +25,7 @@
 				<guid isPermaLink="true">{{ url_for('view_torrent', torrent_id=torrent.id, _external=True) }}</guid>
 				<pubDate>{{ torrent.created_time|rfc822 }}</pubDate>
 			{% endif %}
+			<category>{{ torrent.main_category.name }} - {{ torrent.sub_category.name }}</category>
 			<size>{{ torrent.filesize }}</size>
 			<seeders>{{ torrent.stats.seed_count }}</seeders>
 			<leechers>{{ torrent.stats.leech_count }}</leechers>

--- a/nyaa/templates/rss.xml
+++ b/nyaa/templates/rss.xml
@@ -29,6 +29,7 @@
 			<seeders>{{ torrent.stats.seed_count }}</seeders>
 			<leechers>{{ torrent.stats.leech_count }}</leechers>
 			<downloads>{{ torrent.stats.download_count }}</downloads>
+			<infoHash>{{ compute_hash(torrent.info_hash) }}</infoHash>
 		</item>
 		{% endfor %}
 	</channel>

--- a/nyaa/templates/rss.xml
+++ b/nyaa/templates/rss.xml
@@ -26,7 +26,7 @@
 				<pubDate>{{ torrent.created_time|rfc822 }}</pubDate>
 			{% endif %}
 			<category>{{ torrent.main_category.name }} - {{ torrent.sub_category.name }}</category>
-			<size>{{ torrent.filesize }}</size>
+			<size>{{ torrent.filesize | filesizeformat(True) }}</size>
 			<seeders>{{ torrent.stats.seed_count }}</seeders>
 			<leechers>{{ torrent.stats.leech_count }}</leechers>
 			<downloads>{{ torrent.stats.download_count }}</downloads>


### PR DESCRIPTION
This is intended to fix #34, and also for other auto-downloaders (SickBeard/SickRage/Medusa/etc.)
(**Supersedes #31**)

* Refactor:
  * Only check `if torrent.has_torrent` for the `<link>` element.
* Add elements:
  * description
  * category (formatted as `main_category - sub_category`)
  * size (formatted size) ~_**(in bytes)**_ **I wasn't sure what's better** - size in bytes or formatted size?~
  * seeders
  * leechers
  * downloads
* Add bare torrent hash:
  I'm guessing sometimes users need the torrent hash
  (magnet_uri only shows up when no torrent is available)
  lambda is probably not the best way to go,
  again, wasn't sure - to add a function just for this, to add it in the torrent model, to add a function to `torrents.py`?

### Any suggestions for improvement are welcome!

~I've seen several RSS feeds that use `CDATA` in order to avoid parsing of tags (HTML for example) within the XML document.
I didn't add this, but it should be considered - for data entered by users (`torrent.display_name` and `torrent.description`) and for `magnet_uri`~
```xml
<![CDATA[your text here]]>
```