### PR TITLE
Fix 'Link' column header width

### DIFF
--- a/nyaa/templates/search_results.html
+++ b/nyaa/templates/search_results.html
@@ -19,7 +19,7 @@
 				{% call render_column_header("hdr-name", "width:auto;", sort_key="name") %}
 					<div>Name</div>
 				{% endcall %}
-				{% call render_column_header("hdr-link", "width:0;", center_text=True) %}
+				{% call render_column_header("hdr-link", "width:70px;", center_text=True) %}
 					<div>Link</div>
 				{% endcall %}
 				{% call render_column_header("hdr-size", "width:100px;", center_text=True, sort_key="size") %}


### PR DESCRIPTION
When torrent name is very short (and is the only result), the link column gets too wide.
Setting an optimal width of 70px fixes this.

**Before:** (https://nyaa.si/?q=170513+PV+BATCH&f=0&c=0_0)
![image](https://cloud.githubusercontent.com/assets/10238474/26049749/bf3e4018-3964-11e7-945a-b6ef27ec0e0e.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/10238474/26049819/0a237e72-3965-11e7-914a-18cc61835b0b.png)