### PR TITLE
Fix padding for single file in torrent file list

### DIFF
--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -92,7 +92,7 @@
 						<i class="glyphicon glyphicon-folder-open"></i>&nbsp;&nbsp;<b>{{ key }}</b></td>
 					{{ loop(value.items()) }}
 					{%- else %}
-					<td style="padding-left: {{ loop.depth0 * 20 }}px">
+					<td{% if loop.depth0 is greaterthan 0 %} style="padding-left: {{ loop.depth0 * 20 }}px"{% endif %}>
 						<i class="glyphicon glyphicon-file"></i>&nbsp;{{ key }}</td>
 					<td class="col-md-2">{{ value | filesizeformat(True) }}</td>
 					{%- endif %}


### PR DESCRIPTION
Same thing as I did for the directories on the first level of the tree.

**Before:** (https://nyaa.si/view/923330)
![image](https://cloud.githubusercontent.com/assets/10238474/26097289/c454c586-3a2c-11e7-9daf-18567637571d.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/10238474/26097576/bcb6e45c-3a2d-11e7-975e-24f0635eccad.png)
