### PR TITLE
Issue #35: Mobile search improvements

### DIFF
--- a/nyaa/static/css/main.css
+++ b/nyaa/static/css/main.css
@@ -117,12 +117,12 @@ table.torrent-list thead th.sorting_desc:after {
     width: auto;
 }
 
-#navFilter-category {
+#navFilter-criteria {
     order: 3;
 }
 
-#navFilter-criteria {
-    order: 4;
+#navFilter-category {
+	order: 4;
 }
 
 @media (min-width: 768px) {

--- a/nyaa/static/css/main.css
+++ b/nyaa/static/css/main.css
@@ -99,6 +99,39 @@ table.torrent-list thead th.sorting_desc:after {
 	}
 }
 
+.search-container {
+	display: flex;
+	flex-direction: column;
+}
+
+.form-control.search-bar {
+    order: 1;
+    width: 88%;
+}
+
+.search-btn {
+	order: 2;
+	align-self: flex-end;
+	top: -34px;
+	height: 0;
+    width: auto;
+}
+
+#navFilter-category {
+    order: 3;
+}
+
+#navFilter-criteria {
+    order: 4;
+}
+
+@media (min-width: 768px) {
+	.search-btn {
+		top: 0;
+		width: auto;
+	}
+}
+
 /* elasticsearch term highlight */
 .hlt1 {
     font-style: normal;

--- a/nyaa/static/css/main.css
+++ b/nyaa/static/css/main.css
@@ -106,7 +106,8 @@ table.torrent-list thead th.sorting_desc:after {
 
 .form-control.search-bar {
     order: 1;
-    width: 88%;
+    width: 99%;
+    padding-right: 4em; // Ensure text can not flow under button
 }
 
 .search-btn {
@@ -115,6 +116,7 @@ table.torrent-list thead th.sorting_desc:after {
 	top: -34px;
 	height: 0;
     width: auto;
+	z-index: 3;
 }
 
 #navFilter-criteria {
@@ -125,7 +127,26 @@ table.torrent-list thead th.sorting_desc:after {
 	order: 4;
 }
 
-@media (min-width: 768px) {
+.nav-filter {
+	width: 100%;
+    padding: 1em 0;
+}
+
+.nav-filter .bootstrap-select {
+	width: 100% !important;
+}
+
+.bootstrap-select > button {
+    margin-top: 1em;
+}
+
+/* Allows the bootstrap selects on nav show outside the
+ collapsible section of the navigation */
+.navbar-collapse.in {
+	overflow-y: visible;
+}
+
+@media (min-width: 991px) {
 	.search-btn {
 		top: 0;
 		width: auto;

--- a/nyaa/static/css/main.css
+++ b/nyaa/static/css/main.css
@@ -105,9 +105,9 @@ table.torrent-list thead th.sorting_desc:after {
 }
 
 .form-control.search-bar {
-    order: 1;
-    width: 99%;
-    padding-right: 4em; // Ensure text can not flow under button
+	order: 1;
+	width: 99%;
+	padding-right: 4em; // Ensure text can not flow under button
 }
 
 .search-btn {
@@ -115,12 +115,12 @@ table.torrent-list thead th.sorting_desc:after {
 	align-self: flex-end;
 	top: -34px;
 	height: 0;
-    width: auto;
+	width: auto;
 	z-index: 3;
 }
 
 #navFilter-criteria {
-    order: 3;
+	order: 3;
 }
 
 #navFilter-category {
@@ -129,15 +129,11 @@ table.torrent-list thead th.sorting_desc:after {
 
 .nav-filter {
 	width: 100%;
-    padding: 1em 0;
-}
-
-.nav-filter .bootstrap-select {
-	width: 100% !important;
+	padding: 1em 0;
 }
 
 .bootstrap-select > button {
-    margin-top: 1em;
+	margin-top: 1em;
 }
 
 /* Allows the bootstrap selects on nav show outside the
@@ -150,6 +146,10 @@ table.torrent-list thead th.sorting_desc:after {
 	.search-btn {
 		top: 0;
 		width: auto;
+	}
+
+	.bootstrap-select > button {
+		margin-top: auto;
 	}
 }
 

--- a/nyaa/static/css/main.css
+++ b/nyaa/static/css/main.css
@@ -100,18 +100,28 @@ table.torrent-list thead th.sorting_desc:after {
 }
 
 .search-container {
+	display: -webkit-box;
+	display: -ms-flexbox;
 	display: flex;
+	-webkit-box-orient: vertical;
+	-webkit-box-direction: normal;
+	-ms-flex-direction: column;
 	flex-direction: column;
 }
 
 .form-control.search-bar {
+	-webkit-box-ordinal-group: 2;
+	-ms-flex-order: 1;
 	order: 1;
 	width: 99%;
-	padding-right: 4em; // Ensure text can not flow under button
+	padding-right: 4em;
 }
 
 .search-btn {
+	-webkit-box-ordinal-group: 3;
+	-ms-flex-order: 2;
 	order: 2;
+	-ms-flex-item-align: end;
 	align-self: flex-end;
 	top: -34px;
 	height: 0;
@@ -120,10 +130,14 @@ table.torrent-list thead th.sorting_desc:after {
 }
 
 #navFilter-criteria {
+	-webkit-box-ordinal-group: 4;
+	-ms-flex-order: 3;
 	order: 3;
 }
 
 #navFilter-category {
+	-webkit-box-ordinal-group: 5;
+	-ms-flex-order: 4;
 	order: 4;
 }
 

--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -144,16 +144,16 @@
 				{% else %}
 				<form class="navbar-form navbar-right form" action="/" method="get">
 				{% endif %}
-					<div class="input-group">
-						<input type="text" class="form-control" name="q" placeholder="Search..." value="{{ search["term"] if search is defined else '' }}">
-						<div class="input-group-btn" id="navFilter">
+					<div class="input-group search-container">
+						<input type="text" class="form-control search-bar" name="q" placeholder="Search..." value="{{ search["term"] if search is defined else '' }}">
+						<div class="input-group-btn" id="navFilter-criteria">
 							<select class="selectpicker show-tick" title="Filter" data-width="120px" name="f">
 								<option value="0" title="Show all" {% if search is defined and search["quality_filter"] == "0" %}selected{% else %}selected{% endif %}>Show all</option>
 								<option value="1" title="No remakes" {% if search is defined and search["quality_filter"] == "1" %}selected{% endif %}>No remakes</option>
 								<option value="2" title="Trusted only" {% if search is defined and search["quality_filter"] == "2" %}selected{% endif %}>Trusted only</option>
 							</select>
 						</div>
-						<div class="input-group-btn" id="navFilter">
+						<div class="input-group-btn" id="navFilter-category">
 							{% set nyaa_cats = [('1_0', 'Anime', 'Anime'),
 												('1_1', '- Anime Music Video', 'Anime - AMV'),
 												('1_2', '- English-translated', 'Anime - English'),
@@ -202,7 +202,7 @@
 								{% endfor %}
 							</select>
 						</div>
-						<div class="input-group-btn">
+						<div class="input-group-btn search-btn">
 							<button class="btn btn-primary" type="submit">
 								<i class="fa fa-search fa-fw"></i>
 							</button>

--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -146,14 +146,14 @@
 				{% endif %}
 					<div class="input-group search-container">
 						<input type="text" class="form-control search-bar" name="q" placeholder="Search..." value="{{ search["term"] if search is defined else '' }}">
-						<div class="input-group-btn" id="navFilter-criteria">
+						<div class="input-group-btn nav-filter" id="navFilter-criteria">
 							<select class="selectpicker show-tick" title="Filter" data-width="120px" name="f">
 								<option value="0" title="Show all" {% if search is defined and search["quality_filter"] == "0" %}selected{% else %}selected{% endif %}>Show all</option>
 								<option value="1" title="No remakes" {% if search is defined and search["quality_filter"] == "1" %}selected{% endif %}>No remakes</option>
 								<option value="2" title="Trusted only" {% if search is defined and search["quality_filter"] == "2" %}selected{% endif %}>Trusted only</option>
 							</select>
 						</div>
-						<div class="input-group-btn" id="navFilter-category">
+						<div class="input-group-btn nav-filter" id="navFilter-category">
 							{% set nyaa_cats = [('1_0', 'Anime', 'Anime'),
 												('1_1', '- Anime Music Video', 'Anime - AMV'),
 												('1_2', '- English-translated', 'Anime - English'),


### PR DESCRIPTION
These changes make sure that the mobile search bar is usable on mobile devices or widths. Unfortunately, since we are using Bootstrap select which is a Bootstrap extension, it adjusts the width of the fields via JavaScript which is awfully shit.

![search_bar](https://cloud.githubusercontent.com/assets/2491442/26103596/99167210-3a7d-11e7-9851-d8d9f2078dc3.png)

I don't particularly want to use `!important` in CSS since that's equally as terrible. Let me know if you would any further changes and comments.