### PR TITLE
Add full torrent name to link "title"

### DIFF
--- a/nyaa/templates/search_results.html
+++ b/nyaa/templates/search_results.html
@@ -60,9 +60,9 @@
 				</a>
 				</td>
 				{% if use_elastic %}
-                <td><a href="{{ url_for('view_torrent', torrent_id=torrent.meta.id) }}">{%if "highlight" in torrent.meta %}{{ torrent.meta.highlight.display_name[0] | safe }}{% else %}{{torrent.display_name}}{%endif%}</a></td>
+                <td><a href="{{ url_for('view_torrent', torrent_id=torrent.meta.id) }}" title="{{ torrent.display_name | escape }}">{%if "highlight" in torrent.meta %}{{ torrent.meta.highlight.display_name[0] | safe }}{% else %}{{torrent.display_name}}{%endif%}</a></td>
 				{% else %}
-				<td><a href="{{ url_for('view_torrent', torrent_id=torrent.id) }}">{{ torrent.display_name | escape }}</a></td>
+				<td><a href="{{ url_for('view_torrent', torrent_id=torrent.id) }}" title="{{ torrent.display_name | escape }}">{{ torrent.display_name | escape }}</a></td>
 				{% endif %}
 				<td style="white-space: nowrap;text-align: center;">
 					{% if torrent.has_torrent %}<a href="{{ url_for('download_torrent', torrent_id=torrent.id) }}"><i class="fa fa-fw fa-download"></i></a>{% endif %}

--- a/nyaa/templates/search_results.html
+++ b/nyaa/templates/search_results.html
@@ -60,7 +60,7 @@
 				</a>
 				</td>
 				{% if use_elastic %}
-                <td><a href="{{ url_for('view_torrent', torrent_id=torrent.meta.id) }}" title="{{ torrent.display_name | escape }}">{%if "highlight" in torrent.meta %}{{ torrent.meta.highlight.display_name[0] | safe }}{% else %}{{torrent.display_name}}{%endif%}</a></td>
+				<td><a href="{{ url_for('view_torrent', torrent_id=torrent.meta.id) }}" title="{{ torrent.display_name | escape }}">{%if "highlight" in torrent.meta %}{{ torrent.meta.highlight.display_name[0] | safe }}{% else %}{{torrent.display_name}}{%endif%}</a></td>
 				{% else %}
 				<td><a href="{{ url_for('view_torrent', torrent_id=torrent.id) }}" title="{{ torrent.display_name | escape }}">{{ torrent.display_name | escape }}</a></td>
 				{% endif %}
@@ -74,7 +74,7 @@
 				</td>
 				<td class="text-center">{{ torrent.filesize | filesizeformat(True) }}</td>
 				{% if use_elastic %}
-                <td class="text-center" data-timestamp="{{ torrent.created_time | utc_time }}">{{ torrent.created_time | display_time }}</td>
+				<td class="text-center" data-timestamp="{{ torrent.created_time | utc_time }}">{{ torrent.created_time | display_time }}</td>
 				{% else %}
 				<td class="text-center" data-timestamp="{{ torrent.created_utc_timestamp|int }}">{{ torrent.created_time.strftime('%Y-%m-%d %H:%M') }}</td>
 				{% endif %}


### PR DESCRIPTION
Removed my old PR #74 because it had become a mess.

---
To solve a problem pointed out by someone in the IRC.
User could not read the full name of the torrent

![Image](https://i.imgur.com/sf3U1WA.jpg)

So this will allow the full name to appear on mouseover.

----

**I'll just ask someone to test, since I don't actually have the project and database set up.**