### PR TITLE
Put tracker URL in <kbd>

### DIFF
--- a/nyaa/templates/upload.html
+++ b/nyaa/templates/upload.html
@@ -13,7 +13,7 @@
 
 
 <form method="POST" enctype="multipart/form-data">
-	{% if config.ENFORCE_MAIN_ANNOUNCE_URL %}<p><strong>Important:</strong> Please include <i>{{config.MAIN_ANNOUNCE_URL}}</i> in your trackers</p>{% endif %}
+	{% if config.ENFORCE_MAIN_ANNOUNCE_URL %}<p><strong>Important:</strong> Please include <kbd>{{config.MAIN_ANNOUNCE_URL}}</kbd> in your trackers</p>{% endif %}
 	<div class="row">
 		<div class="form-group col-md-6">
 			{{ render_upload(form.torrent_file, accept=".torrent") }}


### PR DESCRIPTION
Looks nicer (IMO)
***
![image](https://cloud.githubusercontent.com/assets/10238474/26141049/95ca7d12-3ae2-11e7-9279-c8254925eba6.png)
