### PR TITLE
Auto python lint check using Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+
+python:
+  - 3.6
+
+dist: xenial
+sudo: false
+
+cache: pip
+
+install:
+  - pip install --upgrade pep8
+
+script:
+  - pep8 nyaa/ --show-source --max-line-length=100

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,6 @@ install:
 
 script:
   - pep8 nyaa/ --show-source --max-line-length=100
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ sudo: false
 cache: pip
 
 install:
-  - pip install --upgrade pep8
+  - pip install --upgrade pycodestyle
 
 script:
-  - pep8 nyaa/ --show-source --max-line-length=100
+  - pycodestyle nyaa/ --show-source --max-line-length=100
 
 notifications:
   email: false


### PR DESCRIPTION
...So that no one will forget to adhere to PEP8 coding style.

Of course repo owners need to enable the [Travis-CI](https://github.com/integrations/travis-ci) integration for this organization/repo for it to test every commit and pull request.

Output example (of a failed lint check):
![image](https://cloud.githubusercontent.com/assets/10238474/26149201/0de1cc64-3b02-11e7-87ac-ab2dcecd556f.png)
