### PR TITLE
Add ReCaptcha to upload page if user is not logged in.

### DIFF
--- a/nyaa/forms.py
+++ b/nyaa/forms.py
@@ -1,3 +1,4 @@
+import flask
 from nyaa import db, app
 from nyaa.models import User
 from nyaa import bencode, utils, models
@@ -15,6 +16,7 @@ from wtforms.widgets import Select as SelectWidget
 from wtforms.widgets import html_params, HTMLString
 
 from flask_wtf.recaptcha import RecaptchaField
+from flask_wtf.recaptcha.validators import Recaptcha as RecaptchaValidator
 
 
 class Unique(object):
@@ -164,10 +166,6 @@ class EditForm(FlaskForm):
 
 
 class UploadForm(FlaskForm):
-
-    class Meta:
-        csrf = False
-
     torrent_file = FileField('Torrent file', [
         FileRequired()
     ])
@@ -178,6 +176,16 @@ class UploadForm(FlaskForm):
                message='Torrent display name must be at least %(min)d characters long and '
                        '%(max)d at most.')
     ])
+
+    if app.config['USE_RECAPTCHA']:
+        # Captcha only for not logged in users
+        _recaptcha_validator = RecaptchaValidator()
+
+        def _validate_recaptcha(form, field):
+            if not flask.g.user:
+                return UploadForm._recaptcha_validator(form, field)
+
+        recaptcha = RecaptchaField(validators=[_validate_recaptcha])
 
     # category = SelectField('Category')
     category = DisabledSelectField('Category')

--- a/nyaa/routes.py
+++ b/nyaa/routes.py
@@ -558,17 +558,17 @@ def _create_upload_category_choices():
 
 @app.route('/upload', methods=['GET', 'POST'])
 def upload():
-    form = forms.UploadForm(CombinedMultiDict((flask.request.files, flask.request.form)))
-    form.category.choices = _create_upload_category_choices()
+    upload_form = forms.UploadForm(CombinedMultiDict((flask.request.files, flask.request.form)))
+    upload_form.category.choices = _create_upload_category_choices()
 
-    if flask.request.method == 'POST' and form.validate():
-        torrent = backend.handle_torrent_upload(form, flask.g.user)
+    if flask.request.method == 'POST' and upload_form.validate():
+        torrent = backend.handle_torrent_upload(upload_form, flask.g.user)
 
         return flask.redirect('/view/' + str(torrent.id))
     else:
         # If we get here with a POST, it means the form data was invalid: return a non-okay status
         status_code = 400 if flask.request.method == 'POST' else 200
-        return flask.render_template('upload.html', form=form, user=flask.g.user), status_code
+        return flask.render_template('upload.html', upload_form=upload_form), status_code
 
 
 @app.route('/view/<int:torrent_id>')

--- a/nyaa/templates/upload.html
+++ b/nyaa/templates/upload.html
@@ -7,25 +7,27 @@
 
 <h1>Upload Torrent</h1>
 
-{% if not user %}
+{% if not g.user %}
 <p>You are not logged in, and are uploading anonymously.</p>
 {% endif %}
 
 
 <div id="upload-drop-zone"><span>Drop here!</span></div>
 <form method="POST" enctype="multipart/form-data">
-	{% if config.ENFORCE_MAIN_ANNOUNCE_URL %}<p><strong>Important:</strong> Please include <kbd>{{config.MAIN_ANNOUNCE_URL}}</kbd> in your trackers</p>{% endif %}
+	{{ upload_form.csrf_token }}
+
+	{% if config.ENFORCE_MAIN_ANNOUNCE_URL %}<p><strong>Important:</strong> Please include <kbd>{{ config.MAIN_ANNOUNCE_URL }}</kbd> in your trackers</p>{% endif %}
 	<div class="row">
 		<div class="col-md-6">
-		{{ render_upload(form.torrent_file, accept=".torrent") }}
+		{{ render_upload(upload_form.torrent_file, accept=".torrent") }}
 		</div>
 	</div>
 	<div class="row">
 		<div class="col-md-6">
-		{{ render_field(form.display_name, class_='form-control', placeholder='Display name') }}
+		{{ render_field(upload_form.display_name, class_='form-control', placeholder='Display name') }}
 		</div>
 		<div class="col-md-4">
-		{{ render_field(form.category, class_='form-control')}}
+		{{ render_field(upload_form.category, class_='form-control')}}
 		</div>
 	</div>
 	<div class="row">
@@ -33,30 +35,30 @@
 	</div>
 	<div class="row form-group">
 		<div class="col-md-6">
-			{{ render_field(form.information, class_='form-control', placeholder='Your website or IRC channel') }}
+			{{ render_field(upload_form.information, class_='form-control', placeholder='Your website or IRC channel') }}
 		</div>
 		<div class="col-md-6">
 			<label class="control-label">Torrent flags</label>
 			<div>
 			<label class="btn btn-primary" title="Upload torrent anonymously (don't display your username)">
-				{{ form.is_anonymous(disabled=(False if user else ""), checked=(False if user else "")) }}
+				{{ upload_form.is_anonymous(disabled=(False if g.user else ""), checked=(False if g.user else "")) }}
 				Anonymous
 			</label>
 			<label class="btn btn-default" style="background-color: darkgray; border-color: #ccc;" title="Hide torrent from listing">
-				{{ form.is_hidden }}
+				{{ upload_form.is_hidden }}
 				Hidden
 			</label>
 			<label class="btn btn-danger" title="This torrent is derived from another release">
-				{{ form.is_remake }}
+				{{ upload_form.is_remake }}
 				Remake
 			</label>
 			<label class="btn btn-primary" title="This torrent is a complete batch (eg. season)">
-				{{ form.is_complete }}
+				{{ upload_form.is_complete }}
 				Complete
 			</label>
-			{% if user.is_trusted %}
+			{% if g.user.is_trusted %}
 			<label class="btn btn-success" title="Mark torrent trusted">
-				{{ form.is_trusted(checked="") }}
+				{{ upload_form.is_trusted(checked="") }}
 				Trusted
 			</label>
 			{% endif %}
@@ -66,9 +68,22 @@
 	</div>
 	<div class="row">
 		<div class="col-md-12">
-			{{ render_markdown_editor(form.description, field_name='description') }}
+			{{ render_markdown_editor(upload_form.description, field_name='description') }}
 		</div>
 	</div>
+
+	{% if config.USE_RECAPTCHA and not g.user %}
+	<div class="row">
+		<div class="col-md-4">
+			{% for error in upload_form.recaptcha.errors %}
+			{{ error }}
+			{% endfor %}
+			{{ upload_form.recaptcha }}
+		</div>
+	</div>
+	{% endif %}
+
+	<br>
 
 	<div class="row">
 		<div class="form-group col-md-6">


### PR DESCRIPTION
And also bring back CSRF to upload form.

Since we've gotten a few spam torrents, this should be of some help.
However it breaks upload scripts which are using the /upload form.

Should probably wait until upload API v2 is merged before merging this so whoever is still using /upload can migrate to it.