### PR TITLE
Add site flavor and theme to body element as classes

### DIFF
--- a/nyaa/static/js/main.js
+++ b/nyaa/static/js/main.js
@@ -177,3 +177,21 @@ document.addEventListener("DOMContentLoaded", function() {
 // 		localStorage.setItem('theme', 'light');
 // 	}
 // }
+function addThemeClass(){
+	"dark" === localStorage.getItem("theme")?document.body.classList.add('dark'):document.body.classList.add('light');
+}
+
+function replaceThemeClass(){
+	if ("undefined" != typeof document.body) {
+		if (localStorage.getItem('theme') === 'dark') {
+			document.body.classList.remove('light');
+			document.body.classList.add('dark');
+		}
+		else{
+			document.body.classList.remove('dark');
+			document.body.classList.add('light');
+		}
+	}
+}
+
+window.onload=addThemeClass;

--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -22,7 +22,7 @@
 			This theme changer script needs to be inline and right under the above stylesheet link to prevent FOUC (Flash Of Unstyled Content)
 			Development version is commented out in static/js/main.js at the bottom of the file
 		-->
-		<script>function toggleDarkMode(){"dark"===localStorage.getItem("theme")?setThemeLight():setThemeDark()}function setThemeDark(){bsThemeLink.href="/static/css/bootstrap-dark.min.css",localStorage.setItem("theme","dark")}function setThemeLight(){bsThemeLink.href="/static/css/bootstrap.min.css",localStorage.setItem("theme","light")}if("undefined"!=typeof Storage){var bsThemeLink=document.getElementById("bsThemeLink");"dark"===localStorage.getItem("theme")&&setThemeDark()}</script>
+		<script>function toggleDarkMode(){"dark"===localStorage.getItem("theme")?setThemeLight():setThemeDark()}function setThemeDark(){bsThemeLink.href="/static/css/bootstrap-dark.min.css",localStorage.setItem("theme","dark");replaceThemeClass()}function setThemeLight(){bsThemeLink.href="/static/css/bootstrap.min.css",localStorage.setItem("theme","light");replaceThemeClass()}if("undefined"!=typeof Storage){var bsThemeLink=document.getElementById("bsThemeLink");"dark"===localStorage.getItem("theme")&&setThemeDark()}</script>
 		<link href="/static/css/bootstrap-select.min.css" rel="stylesheet">
 		<link href="/static/css/font-awesome.min.css" rel="stylesheet">
 
@@ -43,7 +43,7 @@
 			<script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 		<![endif]-->
 	</head>
-	<body>
+	<body class="{{ config.SITE_FLAVOR }}">
 		<!-- Fixed navbar -->
 		<nav class="navbar navbar-default navbar-static-top navbar-inverse">
 			<div class="container">


### PR DESCRIPTION
Remake of #111.
Related to #37.

This will allow for easier manipulation of the stylesheet.
At the moment throws an error if page is loaded in darkmode, since replaceThemeClass() is only defined after, in main.js.

@aldacron also suggested moving the stuff on <script> to main.js, but the template suggests keeping it inline to prevent FOUC (Flash Of Unstyled Content). Thoughts?

