### PR TITLE
Changed RSS feed to conform to RSS standards and added a namespace

### DIFF
--- a/nyaa/routes.py
+++ b/nyaa/routes.py
@@ -743,6 +743,10 @@ def site_rules():
 def site_help():
     return flask.render_template('help.html')
 
+@app.routes('/xmlns/nyaa', methods=['GET'])
+def xmlns_nyaa():
+    return flask.render_template('xmlns.html')
+
 
 # #################################### API ROUTES ####################################
 @app.route('/api/upload', methods=['POST'])

--- a/nyaa/templates/rss.xml
+++ b/nyaa/templates/rss.xml
@@ -1,4 +1,4 @@
-<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:nyaa="{{ url_for('xmlns_nyaa', _external=True) }}" version="2.0">
 	<channel>
 		<title>{{ config.SITE_NAME }} Torrent File RSS</title>
 		<description>RSS Feed for {{ term }}</description>
@@ -17,10 +17,10 @@
 				<guid isPermaLink="true">{{ url_for('view_torrent', torrent_id=torrent.meta.id, _external=True) }}</guid>
 				<pubDate>{{ torrent.created_time|rfc822_es }}</pubDate>
 
-				<seeders>  {{- torrent.seed_count     }}</seeders>
-				<leechers> {{- torrent.leech_count    }}</leechers>
-				<downloads>{{- torrent.download_count }}</downloads>
-				<infoHash> {{- torrent.info_hash      }}</infoHash>
+				<nyaa:seeders>  {{- torrent.seed_count     }}</nyaa:seeders>
+				<nyaa:leechers> {{- torrent.leech_count    }}</nyaa:leechers>
+				<nyaa:downloads>{{- torrent.download_count }}</nyaa:downloads>
+				<nyaa:infoHash> {{- torrent.info_hash      }}</nyaa:infoHash>
 			{% else %}
 				{% if torrent.has_torrent and not magnet_links %}
 				<link>{{ url_for('download_torrent', torrent_id=torrent.id, _external=True) }}</link>
@@ -30,15 +30,15 @@
 				<guid isPermaLink="true">{{ url_for('view_torrent', torrent_id=torrent.id, _external=True) }}</guid>
 				<pubDate>{{ torrent.created_time|rfc822 }}</pubDate>
 
-				<seeders>  {{- torrent.stats.seed_count     }}</seeders>
-				<leechers> {{- torrent.stats.leech_count    }}</leechers>
-				<downloads>{{- torrent.stats.download_count }}</downloads>
-				<infoHash> {{- torrent.info_hash_as_hex     }}</infoHash>
+				<nyaa:seeders>  {{- torrent.stats.seed_count     }}</nyaa:seeders>
+				<nyaa:leechers> {{- torrent.stats.leech_count    }}</nyaa:leechers>
+				<nyaa:downloads>{{- torrent.stats.download_count }}</nyaa:downloads>
+				<nyaa:infoHash> {{- torrent.info_hash_as_hex     }}</nyaa:infoHash>
 			{% endif %}
 			{% set cat_id = use_elastic and ((torrent.main_category_id|string) + '_' + (torrent.sub_category_id|string)) or torrent.sub_category.id_as_string %}
-			<categoryId>{{- cat_id }}</categoryId>
-			<category>  {{- category_name(cat_id) }}</category>
-			<size>      {{- torrent.filesize | filesizeformat(True) }}</size>
+			<nyaa:categoryId>{{- cat_id }}</nyaa:categoryId>
+			<nyaa:category>  {{- category_name(cat_id) }}</nyaa:category>
+			<nyaa:size>      {{- torrent.filesize | filesizeformat(True) }}</nyaa:size>
 		</item>
 		{% endfor %}
 	</channel>

--- a/nyaa/templates/xmlns.html
+++ b/nyaa/templates/xmlns.html
@@ -1,0 +1,32 @@
+{% extends "layout.html" %}
+{% block title %}XML Namespace :: {{ config.SITE_NAME }}{% endblock %}
+{% block body %}
+<div class="content">
+    <h1>Nyaa XML Namespace</h1>
+    <p>You found this page because our RSS feeds contain an URL that links here. Said URL is not an actual page but rather a unique identifier used to prevent name collisions with other XML namespaces.</p>
+    <p>The namespace contains the following additional, informational <b>tags</b>:</p>
+    <ul>
+        <li>
+            <p><code>&lt;nyaa:seeders&gt;</code> holds the current amount of seeders on the respective torrent.</p>
+        </li>
+        <li>
+            <p><code>&lt;nyaa:leechers&gt;</code> holds the current amount of leechers on the respective torrent.</p>
+        </li>
+        <li>
+            <p><code>&lt;nyaa:downloads&gt;</code> counts the downloads the torrent got up to the point the feed was refreshed.</p>
+        </li>
+        <li>
+            <p><code>&lt;nyaa:infoHash&gt;</code> is the torrent's infohash, a unique identifier, in hexadecimal.</p>
+        </li>
+        <li>
+            <p><code>&lt;nyaa:categoryId&gt;</code> contains the ID of the category containing the upload in the form <code>category_subcategory</code>.</p>
+        </li>
+        <li>
+            <p><code>&lt;nyaa:category&gt;</code> contains the written name of the torrent's category in the form <code>Category - Subcategory</code>.</p>
+        </li>
+        <li>
+            <p><code>&lt;nyaa:size&gt;</code> indicates the torrent's download size to one decimal place, using a magnitude prefix according to ISO/IEC 80000-13.</p>
+        </li>
+    </ul>
+</div>
+{% endblock %}


### PR DESCRIPTION
I reworked the output of the feed generator and replaced the custom `seeders`, `leecher`, `infoHash`, `category_Id`, `category`, and `size` tags with namespace-prefixed versions to conform to RSS standard.  
To provide said namespace I added an endpoint for the URI, as well as an HTML document for information on the it.