### PR TITLE
Restructure upload edit

### DIFF
--- a/nyaa/forms.py
+++ b/nyaa/forms.py
@@ -153,6 +153,7 @@ class EditForm(FlaskForm):
     is_remake = BooleanField('Remake')
     is_anonymous = BooleanField('Anonymous')
     is_complete = BooleanField('Complete')
+    is_trusted = BooleanField('Trusted')
 
     information = StringField('Information', [
         Length(max=255, message='Information must be at most %(max)d characters long.')
@@ -200,6 +201,7 @@ class UploadForm(FlaskForm):
     is_remake = BooleanField('Remake')
     is_anonymous = BooleanField('Anonymous')
     is_complete = BooleanField('Complete')
+    is_trusted = BooleanField('Trusted')
 
     information = StringField('Information', [
         Length(max=255, message='Information must be at most %(max)d characters long.')

--- a/nyaa/models.py
+++ b/nyaa/models.py
@@ -382,15 +382,15 @@ class User(db.Model):
 
     @property
     def is_admin(self):
-        return self.level is UserLevelType.ADMIN or self.level is UserLevelType.SUPERADMIN
+        return self.level >= UserLevelType.ADMIN
 
     @property
     def is_superadmin(self):
-        return self.level is UserLevelType.SUPERADMIN
+        return self.level == UserLevelType.SUPERADMIN
 
     @property
     def is_trusted(self):
-        return self.level is UserLevelType.TRUSTED
+        return self.level >= UserLevelType.TRUSTED
 
 
 # class Session(db.Model):

--- a/nyaa/routes.py
+++ b/nyaa/routes.py
@@ -555,7 +555,8 @@ def _create_upload_category_choices():
         cat_names = id_map[key]
         is_main_cat = key.endswith('_0')
 
-        cat_name = is_main_cat and cat_names[0] or (' - ' + cat_names[1])
+        # cat_name = is_main_cat and cat_names[0] or (' - ' + cat_names[1])
+        cat_name = ' - '.join(cat_names)
         choices.append((key, cat_name, is_main_cat))
     return choices
 

--- a/nyaa/templates/_formhelpers.html
+++ b/nyaa/templates/_formhelpers.html
@@ -1,10 +1,12 @@
-{% macro render_field(field) %}
+{% macro render_field(field, render_label=True) %}
 {% if field.errors %}
 	<div class="form-group has-error">
 {% else %}
 	<div class="form-group">
 {% endif %}
+		{% if render_label %}
 		{{ field.label(class='control-label') }}
+		{% endif %}
 		{{ field(title=field.description,**kwargs) | safe }}
 		{% if field.errors %}
 			<div class="help-block">
@@ -27,33 +29,33 @@
 
 {% macro render_markdown_editor(field, field_name='') %}
 {% if field.errors %}
-    <div class="form-group has-error">
+	<div class="form-group has-error">
 {% else %}
-    <div class="form-group">
+	<div class="form-group">
 {% endif %}
-    <div class="markdown-editor" id="{{ field_name }}-markdown-editor" data-field-name="{{ field_name }}">
-        <ul class="nav nav-tabs" role="tablist">
-            <li role="presentation" class="active">
-                <a href="#{{ field_name }}-tab" aria-controls="" role="tab" data-toggle="tab">
-                    Write
-                </a>
-            </li>
-            <li role="presentation">
-                <a href="#{{ field_name }}-preview" id="{{ field_name }}-preview-tab" aria-controls="preview" role="tab" data-toggle="tab">
-                    Preview
-                </a>
-            </li>
-        </ul>
-        <div class="tab-content">
-            <div role="tabpanel" class="tab-pane active" id="{{ field_name }}-tab" data-markdown-target="#{{ field_name }}-markdown-target">
-                {{ render_field(field, class_='form-control markdown-source') }}
-            </div>
-            <div role="tabpanel" class="tab-pane" id="{{ field_name }}-preview">
-                {{ field.label(class='control-label') }}
-                <div class="well" id="{{ field_name }}-markdown-target"></div>
-            </div>
-        </div>
-    </div>
+	<div class="markdown-editor" id="{{ field_name }}-markdown-editor" data-field-name="{{ field_name }}">
+		{{ field.label(class='control-label') }}
+		<ul class="nav nav-tabs" role="tablist">
+			<li role="presentation" class="active">
+				<a href="#{{ field_name }}-tab" aria-controls="" role="tab" data-toggle="tab">
+					Write
+				</a>
+			</li>
+			<li role="presentation">
+				<a href="#{{ field_name }}-preview" id="{{ field_name }}-preview-tab" aria-controls="preview" role="tab" data-toggle="tab">
+					Preview
+				</a>
+			</li>
+		</ul>
+		<div class="tab-content">
+			<div role="tabpanel" class="tab-pane active" id="{{ field_name }}-tab" data-markdown-target="#{{ field_name }}-markdown-target">
+				{{ render_field(field, False, class_='form-control markdown-source') }}
+			</div>
+			<div role="tabpanel" class="tab-pane" id="{{ field_name }}-preview">
+				<div class="well" id="{{ field_name }}-markdown-target"></div>
+			</div>
+		</div>
+	</div>
 </div>
 {% endmacro %}
 

--- a/nyaa/templates/edit.html
+++ b/nyaa/templates/edit.html
@@ -25,10 +25,10 @@
 		</div>
 	</div>
 	<div class="row">
-		<div class="col-md-4">
+		<div class="col-md-6">
 		{{ render_field(form.information, class_='form-control', placeholder='Your website or IRC channel') }}
 		</div>
-		<div class="col-md-8">
+		<div class="col-md-6">
 			<label class="control-label">Torrent flags</label>
 			<div>
 			{% if editor.is_admin %}

--- a/nyaa/templates/edit.html
+++ b/nyaa/templates/edit.html
@@ -4,79 +4,73 @@
 {% from "_formhelpers.html" import render_field %}
 {% from "_formhelpers.html" import render_markdown_editor %}
 
-<h1>Edit Torrent</h1>
+{% set torrent_url = url_for('view_torrent', torrent_id=torrent.id) %}
+<h1>
+	Edit Torrent <a href="{{ torrent_url }}">#{{torrent.id}}</a>
+	{% if (torrent.user != None) and (torrent.user != editor) %}
+	(by <a href="{{ url_for('view_user', user_name=torrent.user.username) }}">{{ torrent.user.username }}</a>)
+	{% endif %}
+</h1>
 
 <form method="POST" enctype="multipart/form-data">
 	{{ form.csrf_token }}
 
+
 	<div class="row">
-		<div class="form-group col-md-6">
-			{{ render_field(form.category, class_='form-control')}}
+		<div class="col-md-6">
+		{{ render_field(form.display_name, class_='form-control', placeholder='Display name') }}
+		</div>
+		<div class="col-md-4">
+		{{ render_field(form.category, class_='form-control')}}
 		</div>
 	</div>
-
 	<div class="row">
-		<div class="form-group col-md-6">
-			{{ render_field(form.display_name, class_='form-control', placeholder='Display name') }}
+		<div class="col-md-4">
+		{{ render_field(form.information, class_='form-control', placeholder='Your website or IRC channel') }}
 		</div>
-	</div>
+		<div class="col-md-8">
+			<label class="control-label">Torrent flags</label>
+			<div>
+			{% if editor.is_admin %}
+			<label class="btn btn-primary">
+				{{ form.is_deleted }}
+				Deleted
+			</label>
+			{% endif %}
 
-	<div class="row">
-		<div class="form-group col-md-6">
-			{{ render_field(form.information, class_='form-control', placeholder='Your website or IRC channel') }}
-		</div>
-	</div>
-
-	<div class="row">
-		<div class="form-group col-md-6">
-			{{ render_markdown_editor(form.description, field_name='description') }}
-		</div>
-	</div>
-
-	{% if admin %}
-		<div class="row">
-	 		<div class="form-group col-md-6">
-				<label>
-					{{ form.is_deleted }}
-					Deleted
-				</label>
-			</div>
-		</div>
-	{% endif %}
-
-	<div class="row">
-		<div class="form-group col-md-6">
-			<label>
+			<label class="btn btn-default" style="background-color: darkgray; border-color: #ccc;" title="Hide torrent from listing">
 				{{ form.is_hidden }}
 				Hidden
 			</label>
-		</div>
-	</div>
-
-	<div class="row">
-		<div class="form-group col-md-6">
-			<label>
+			<label class="btn btn-danger" title="This torrent is derived from another release">
 				{{ form.is_remake }}
 				Remake
 			</label>
-		</div>
-	</div>
-
-	<div class="row">
-		<div class="form-group col-md-6">
-			<label>
+			<label class="btn btn-primary" title="This torrent is a complete batch (eg. season)">
 				{{ form.is_complete }}
 				Complete
 			</label>
+
+			{# Only allow changing anonymous status when an uploader exists #}
+			{% if torrent.uploader_id %}
+			<label class="btn btn-primary" title="Upload torrent anonymously (don't display your username)">
+				{{ form.is_anonymous }}
+				Anonymous
+			</label>
+			{% endif %}
+			{% if editor.is_trusted %}
+			<label class="btn btn-success" title="Mark torrent trusted">
+				{{ form.is_trusted }}
+				Trusted
+			</label>
+			{% endif %}
+			</div>
 		</div>
 	</div>
 
 	<div class="row">
-		<div class="form-group col-md-6">
-			<label>
-				{{ form.is_anonymous }}
-				Anonymous
-			</label>
+		<div class="col-md-12">
+			{{ render_markdown_editor(form.description, field_name='description') }}
 		</div>
 	</div>
 

--- a/nyaa/templates/upload.html
+++ b/nyaa/templates/upload.html
@@ -32,12 +32,16 @@
 
 	</div>
 	<div class="row form-group">
-		<div class="col-md-4">
+		<div class="col-md-6">
 			{{ render_field(form.information, class_='form-control', placeholder='Your website or IRC channel') }}
 		</div>
-		<div class="col-md-8">
+		<div class="col-md-6">
 			<label class="control-label">Torrent flags</label>
 			<div>
+			<label class="btn btn-primary" title="Upload torrent anonymously (don't display your username)">
+				{{ form.is_anonymous(disabled=(False if user else ""), checked=(False if user else "")) }}
+				Anonymous
+			</label>
 			<label class="btn btn-default" style="background-color: darkgray; border-color: #ccc;" title="Hide torrent from listing">
 				{{ form.is_hidden }}
 				Hidden
@@ -49,10 +53,6 @@
 			<label class="btn btn-primary" title="This torrent is a complete batch (eg. season)">
 				{{ form.is_complete }}
 				Complete
-			</label>
-			<label class="btn btn-primary" title="Upload torrent anonymously (don't display your username)">
-				{{ form.is_anonymous(disabled=(False if user else ""), checked=(False if user else "")) }}
-				Anonymous
 			</label>
 			{% if user.is_trusted %}
 			<label class="btn btn-success" title="Mark torrent trusted">

--- a/nyaa/templates/upload.html
+++ b/nyaa/templates/upload.html
@@ -16,68 +16,57 @@
 <form method="POST" enctype="multipart/form-data">
 	{% if config.ENFORCE_MAIN_ANNOUNCE_URL %}<p><strong>Important:</strong> Please include <kbd>{{config.MAIN_ANNOUNCE_URL}}</kbd> in your trackers</p>{% endif %}
 	<div class="row">
-		<div class="form-group col-md-6">
-			{{ render_upload(form.torrent_file, accept=".torrent") }}
+		<div class="col-md-6">
+		{{ render_upload(form.torrent_file, accept=".torrent") }}
 		</div>
 	</div>
-
 	<div class="row">
-		<div class="form-group col-md-6">
-			{{ render_field(form.category, class_='form-control')}}
+		<div class="col-md-6">
+		{{ render_field(form.display_name, class_='form-control', placeholder='Display name') }}
+		</div>
+		<div class="col-md-4">
+		{{ render_field(form.category, class_='form-control')}}
 		</div>
 	</div>
-
 	<div class="row">
-		<div class="form-group col-md-6">
-			{{ render_field(form.display_name, class_='form-control', placeholder='Display name') }}
-		</div>
+
 	</div>
-
-	<div class="row">
-		<div class="form-group col-md-6">
+	<div class="row form-group">
+		<div class="col-md-4">
 			{{ render_field(form.information, class_='form-control', placeholder='Your website or IRC channel') }}
 		</div>
-	</div>
-
-    <div class="row">
-        <div class="form-group col-md-6">
-            {{ render_markdown_editor(form.description, field_name='description') }}
-        </div>
-    </div>
-
-	<div class="row">
-		<div class="form-group col-md-6">
-			<label>
+		<div class="col-md-8">
+			<label class="control-label">Torrent flags</label>
+			<div>
+			<label class="btn btn-default" style="background-color: darkgray; border-color: #ccc;" title="Hide torrent from listing">
 				{{ form.is_hidden }}
 				Hidden
 			</label>
-		</div>
-	</div>
-
-	<div class="row">
-		<div class="form-group col-md-6">
-			<label>
+			<label class="btn btn-danger" title="This torrent is derived from another release">
 				{{ form.is_remake }}
 				Remake
 			</label>
-		</div>
-	</div>
-
-	<div class="row">
-		<div class="form-group col-md-6">
-			<label>
+			<label class="btn btn-primary" title="This torrent is a complete batch (eg. season)">
 				{{ form.is_complete }}
 				Complete
 			</label>
-		</div>
-	</div>
-
-	<div class="row">
-		<div class="form-group col-md-6">
-			<label>
-				{{ form.is_anonymous }}
+			<label class="btn btn-primary" title="Upload torrent anonymously (don't display your username)">
+				{{ form.is_anonymous(disabled=(False if user else ""), checked=(False if user else "")) }}
 				Anonymous
 			</label>
+			{% if user.is_trusted %}
+			<label class="btn btn-success" title="Mark torrent trusted">
+				{{ form.is_trusted(checked="") }}
+				Trusted
+			</label>
+			{% endif %}
+			</div>
+		</div>
+
+	</div>
+	<div class="row">
+		<div class="col-md-12">
+			{{ render_markdown_editor(form.description, field_name='description') }}
 		</div>
 	</div>
 

--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -5,7 +5,7 @@
 	<div class="panel-heading"{% if torrent.hidden %} style="background-color: darkgray;"{% endif %}>
 		<h3 class="panel-title">
 			{% if can_edit %}
-			<a href="{{ request.url }}/edit"><i class="fa fa-fw fa-pencil"></i></a>
+			<a href="{{ request.url }}/edit" title="Edit torrent"><i class="fa fa-fw fa-pencil"></i></a>
 			{% endif %}
 			{{ torrent.display_name }}
 		</h3>
@@ -23,7 +23,14 @@
 
 		<div class="row">
 			<div class="col-md-1">Submitter:</div>
-			<div class="col-md-5">{% if not torrent.anonymous and torrent.user %}<a href="{{ url_for('view_user', user_name=torrent.user.username) }}">{{ torrent.user.username }}</a>{% else %}Anonymous{% endif %}</div>
+			<div class="col-md-5">
+			{% set user_url = torrent.user and url_for('view_user', user_name=torrent.user.username) %}
+			{%- if not torrent.anonymous and torrent.user -%}
+			<a href="{{ user_url }}">{{ torrent.user.username }}</a>
+			{%- else -%}
+			Anonymous {% if torrent.user and (viewer == torrent.user or viewer.is_admin) %}(<a href="{{ user_url }}">{{ torrent.user.username }}</a>){% endif %}
+			{%- endif -%}
+			</div>
 
 			<div class="col-md-1">Seeders:</div>
 			<div class="col-md-5"><span style="color: green;">{% if config.ENABLE_SHOW_STATS %}{{ torrent.stats.seed_count }}{% else %}Coming soon{% endif %}</span></div>


### PR DESCRIPTION
*Edited in af0cca2:* Updated upload/edit images:
Align information & flags:
![image](https://cloud.githubusercontent.com/assets/6820963/26278926/126123e8-3daf-11e7-9ad5-fe74ab61f010.png)

Show full category names to fill out the field:
![image](https://cloud.githubusercontent.com/assets/6820963/26278928/203ea418-3daf-11e7-802b-cc5122387fcb.png)


---
See latter commit for list of changes.

Screens below:
## Upload:
### Currently:
![image](https://cloud.githubusercontent.com/assets/6820963/26278690/3d4617ea-3da9-11e7-94f1-1ce28f88a05e.png)

### PR:
(note: `ENFORCE_MAIN_TRACKER` is unset; the notice is not removed from templates)
### Logged in as Trusted or above:
![image](https://cloud.githubusercontent.com/assets/6820963/26278708/a59ede58-3da9-11e7-80b1-a25fc86d482b.png)
### Logged in as regular:
![image](https://cloud.githubusercontent.com/assets/6820963/26278714/c07af3a6-3da9-11e7-8455-419044fa92e1.png)
### Not logged in:
![image](https://cloud.githubusercontent.com/assets/6820963/26278716/ca0d7768-3da9-11e7-9610-74b65e1f3605.png)

----
## Edit:
### Currently:
![image](https://cloud.githubusercontent.com/assets/6820963/26278726/15ec3ee4-3daa-11e7-9c88-e9ee2b4c587d.png)

### PR:
### Editing your own torrent:
![image](https://cloud.githubusercontent.com/assets/6820963/26278769/299375d8-3dab-11e7-874c-7d8c623df417.png)

### Admin editing someone else's torrent:
![image](https://cloud.githubusercontent.com/assets/6820963/26278777/57e25fbc-3dab-11e7-9730-b66d49b04858.png)

### Regular user editing their torrent:
![image](https://cloud.githubusercontent.com/assets/6820963/26278783/6ef6265c-3dab-11e7-844f-bde212d1b782.png)

---
### For admins, show real owner for torrents marked as anonymous:
![image](https://cloud.githubusercontent.com/assets/6820963/26278794/c93ff520-3dab-11e7-87e4-0bf674b22752.png)
