### PR TITLE
Info hash search, hash on torrent page, template adjustments

### DIFF
--- a/nyaa/models.py
+++ b/nyaa/models.py
@@ -205,6 +205,11 @@ class Torrent(db.Model):
     def by_info_hash(cls, info_hash):
         return cls.query.filter_by(info_hash=info_hash).first()
 
+    @classmethod
+    def by_info_hash_hex(cls, info_hash_hex):
+        info_hash_bytes = bytearray.fromhex(info_hash_hex)
+        return cls.by_info_hash(info_hash_bytes)
+
 
 class TorrentNameSearch(FullText, Torrent):
     __fulltext_columns__ = ('display_name',)

--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -57,6 +57,7 @@
 					</button>
 					<a class="navbar-brand" href="/">{{ config.SITE_NAME }}</a>
 				</div>
+				{% set search_placeholder = 'Search {}\'s torrents...'.format(user.username) if user_page else 'Search...' %}
 				<div id="navbar" class="navbar-collapse collapse">
 					<ul class="nav navbar-nav">
 						<li {% if request.path == "/upload" %} class="active"{% endif %}><a href="/upload">Upload</a></li>
@@ -193,11 +194,10 @@
 						{% else %}
 						<form class="navbar-form navbar-right form" action="/" method="get">
 						{% endif %}
-	
-							<input type="text" class="form-control" name="q" placeholder="Search..." value="{{ search["term"] if search is defined else '' }}">
-	
-							<br>
 							
+							<input type="text" class="form-control" name="q" placeholder="{{ search_placeholder }}" value="{{ search["term"] if search is defined else '' }}">
+							<br>
+
 							<select class="form-control" title="Filter" data-width="120px" name="f">
 								<option value="0" title="No filter" {% if search is defined and search["quality_filter"] == "0" %}selected{% else %}selected{% endif %}>No filter</option>
 								<option value="1" title="No remakes" {% if search is defined and search["quality_filter"] == "1" %}selected{% endif %}>No remakes</option>
@@ -231,7 +231,7 @@
 					<form class="navbar-form navbar-right form" action="/" method="get">
 					{% endif %}
 						<div class="input-group search-container hidden-xs hidden-sm">
-							<input type="text" class="form-control search-bar" name="q" placeholder="Search..." value="{{ search["term"] if search is defined else '' }}">
+							<input type="text" class="form-control search-bar" name="q" placeholder="{{ search_placeholder }}" value="{{ search["term"] if search is defined else '' }}">
 					
 							<div class="input-group-btn nav-filter" id="navFilter-criteria">
 								<select class="selectpicker show-tick" title="Filter" data-width="120px" name="f">

--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -57,7 +57,8 @@
 					</button>
 					<a class="navbar-brand" href="/">{{ config.SITE_NAME }}</a>
 				</div>
-				{% set search_placeholder = 'Search {}\'s torrents...'.format(user.username) if user_page else 'Search...' %}
+				{% set search_username = (user.username + ("'" if user.username[-1] == 's' else "'s")) if user_page else None %}
+				{% set search_placeholder = 'Search {} torrents...'.format(search_username) if user_page else 'Search...' %}
 				<div id="navbar" class="navbar-collapse collapse">
 					<ul class="nav navbar-nav">
 						<li {% if request.path == "/upload" %} class="active"{% endif %}><a href="/upload">Upload</a></li>

--- a/nyaa/templates/search_results.html
+++ b/nyaa/templates/search_results.html
@@ -9,10 +9,10 @@
 </th>
 {% endmacro %}
 
-{% if user_query is defined %}
-{% if user_query.first_word_user and not search.user %}
+{% if special_results is defined and not search.user %}
+{% if special_results.first_word_user %}
 <div class="alert alert-info">
-	<a href="/user/{{ user_query.first_word_user.username }}{{ modify_query(q=user_query.query_sans_user)[1:] }}">Click here to see only results uploaded by {{ user_query.first_word_user.username }}</a>
+	<a href="/user/{{ special_results.first_word_user.username }}{{ modify_query(q=special_results.query_sans_user)[1:] }}">Click here to see only results uploaded by {{ special_results.first_word_user.username }}</a>
 </div>
 {% endif %}
 {% endif %}

--- a/nyaa/templates/user.html
+++ b/nyaa/templates/user.html
@@ -41,7 +41,7 @@
 {% endif %}
 
 <h3>
-    Browsing <span class="text-{{ user.userlevel_color }}">{{ user.username }}</span>'s torrents
+    Browsing <span class="text-{{ user.userlevel_color }}">{{ user.username }}</span>'{{ '' if user.username[-1] == 's' else 's' }} torrents
 </h3>
 
 {% include "search_results.html" %}

--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -62,6 +62,10 @@
 			<div class="col-md-1">Completed:</div>
 			<div class="col-md-5">{% if config.ENABLE_SHOW_STATS %}{{ torrent.stats.download_count }}{% else %}Coming soon{% endif %}</div>
 		</div>
+		<div class="row">
+			<div class="col-md-offset-6 col-md-1">SHA-1 hash:</div>
+			<div class="col-md-5"><kbd>{{ torrent.info_hash_as_hex }}</kbd></div>
+		</div>
 	</div>
 	<div class="panel-footer">
 		{% if torrent.has_torrent %}<a href="/view/{{ torrent.id }}/torrent"><i class="fa fa-download fa-fw"></i>Download Torrent</a> or {% endif %}<a href="{{ torrent.magnet_uri }}" class="card-footer-item"><i class="fa fa-magnet fa-fw"></i>Magnet</a>


### PR DESCRIPTION
PR for image previews.

Fixes #174 

Torrent hash on torrent pages:
![image](https://cloud.githubusercontent.com/assets/6820963/26408188/cfcbef96-40a5-11e7-89f4-6b36282f397e.png)

Searching for a hex representation of a hash as the sole input (eg. `5c39cf8ba80757a409d51bdacffab644f8a4960e`) will redirect to the torrent, if found:
![image](https://cloud.githubusercontent.com/assets/6820963/26408298/0e4ef560-40a6-11e7-90cc-7251dbb517c8.png)
(RSS or user page searches are not redirected)

Search field placeholder will show "Search for <user>'s torrents":
![image](https://cloud.githubusercontent.com/assets/6820963/26408352/34770ca0-40a6-11e7-9c6b-1c149e78bdb5.png)
