### PR TITLE
Add site flavor and darkmode to body css class

### DIFF
--- a/nyaa/static/js/main.js
+++ b/nyaa/static/js/main.js
@@ -185,3 +185,9 @@ document.addEventListener("DOMContentLoaded", function() {
 // 		localStorage.setItem('theme', 'light');
 // 	}
 // }
+
+function addThemeClass(){
+	"dark" === localStorage.getItem("theme") && document.body.classList.add('dark')
+}
+
+window.addEventListener("load", addThemeClass, false);

--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -23,7 +23,7 @@
 			This theme changer script needs to be inline and right under the above stylesheet link to prevent FOUC (Flash Of Unstyled Content)
 			Development version is commented out in static/js/main.js at the bottom of the file
 		-->
-		<script>function toggleDarkMode(){"dark"===localStorage.getItem("theme")?setThemeLight():setThemeDark()}function setThemeDark(){bsThemeLink.href="/static/css/bootstrap-dark.min.css",localStorage.setItem("theme","dark")}function setThemeLight(){bsThemeLink.href="/static/css/bootstrap.min.css",localStorage.setItem("theme","light")}if("undefined"!=typeof Storage){var bsThemeLink=document.getElementById("bsThemeLink");"dark"===localStorage.getItem("theme")&&setThemeDark()}</script>
+		<script>function toggleDarkMode(){"dark"===localStorage.getItem("theme")?setThemeLight():setThemeDark()}function setThemeDark(){bsThemeLink.href="/static/css/bootstrap-dark.min.css",localStorage.setItem("theme","dark");document.body.classList.add('dark')}function setThemeLight(){bsThemeLink.href="/static/css/bootstrap.min.css",localStorage.setItem("theme","light");document.body.classList.remove('dark')}if("undefined"!=typeof Storage){var bsThemeLink=document.getElementById("bsThemeLink");"dark"===localStorage.getItem("theme")&&setThemeDark()}</script>
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.2/css/bootstrap-select.min.css" integrity="sha256-an4uqLnVJ2flr7w0U74xiF4PJjO2N5Df91R2CUmCLCA=" crossorigin="anonymous" />
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
 
@@ -44,7 +44,7 @@
 			<script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 		<![endif]-->
 	</head>
-	<body>
+	<body class="{{ config.SITE_FLAVOR }}">
 		<!-- Fixed navbar -->
 		<nav class="navbar navbar-default navbar-static-top navbar-inverse">
 			<div class="container">
@@ -292,5 +292,3 @@
 		</footer>
 	</body>
 </html>
-
-


### PR DESCRIPTION
Retake on #138. Got in trouble resolving the conflict, so created a new PR instead.
Related to issue #37.

This will allow for easier manipulation of the stylesheet, as `<body>` will have "dark" as a class if dark mode is enabled.

addThemeClass() was added to main.js because the inline script can't touch `<body>` since it won't exist yet at that point.