### PR TITLE
75 Adjusts CSS for Sukebei

### DIFF
--- a/nyaa/static/css/sukebei.css
+++ b/nyaa/static/css/sukebei.css
@@ -1,0 +1,14 @@
+.sukebei .navbar{
+  background-color: #d81b60;
+  border-bottom: #a00037;
+}
+.sukebei #navbar > ul > li > a, .sukebei .navbar-brand {
+  color: rgba(255, 255, 255, 0.7);
+  transition: all .15s ease-in-out;
+}
+.sukebei #navbar > ul > li > a:hover {
+  color: #fff;
+}
+.sukebei #navbar li.active > a, .sukebei #navbar li.open > a{
+  background-color: #a00037;
+}

--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -39,6 +39,7 @@
 
 		<!-- Custom styles for this template -->
 		<link href="{{ static_cachebuster('css/main.css') }}" rel="stylesheet">
+		<link href="{{ static_cachebuster('css/sukebei.css') }}" rel="stylesheet">
 
 		<!-- Core JavaScript -->
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
@@ -54,7 +55,7 @@
 			<script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 		<![endif]-->
 	</head>
-	<body>
+	<body class="{{ config.SITE_FLAVOR }}">
 		<!-- Fixed navbar -->
 		<nav class="navbar navbar-default navbar-static-top navbar-inverse">
 			<div class="container">


### PR DESCRIPTION
#75 
Modified layout.html to include the current site flavor so
it'll be easier to add flavor specific styles later.

I was unsure of how much we wanted Sukebei's styling to differ from the main site so I kept the changes to just the navbar. I was also unsure how we wanted to compress assets, so for the moment I just followed how main.css was inserted. I see we have flask_assets in the code base but it looks like we're not using it.

![ss 2017-05-29 at 02 06 48](https://cloud.githubusercontent.com/assets/993812/26530657/117237e0-4414-11e7-87f7-5b9a4349e573.png)
![ss 2017-05-29 at 02 07 07](https://cloud.githubusercontent.com/assets/993812/26530658/1333e0c4-4414-11e7-931f-b169df2dc194.png)
