### PR TITLE
Move to markdown-it

### DIFF
--- a/nyaa/forms.py
+++ b/nyaa/forms.py
@@ -168,7 +168,7 @@ class EditForm(FlaskForm):
     information = StringField('Information', [
         Length(max=255, message='Information must be at most %(max)d characters long.')
     ])
-    description = TextAreaField('Description (markdown supported)', [
+    description = TextAreaField('Description', [
         Length(max=10 * 1024, message='Description must be at most %(max)d characters long.')
     ])
 
@@ -222,7 +222,7 @@ class UploadForm(FlaskForm):
     information = StringField('Information', [
         Length(max=255, message='Information must be at most %(max)d characters long.')
     ])
-    description = TextAreaField('Description (markdown supported)', [
+    description = TextAreaField('Description', [
         Length(max=10 * 1024, message='Description must be at most %(max)d characters long.')
     ])
 

--- a/nyaa/static/js/main.js
+++ b/nyaa/static/js/main.js
@@ -145,28 +145,46 @@ document.addEventListener("DOMContentLoaded", function(event) {
 	}
 });
 
+var markdownOptions = {
+	html : false,
+	breaks : true,
+	typographer:  true
+}
+var markdown = window.markdownit(markdownOptions);
+markdown.renderer.rules.table_open = function (tokens, idx) {
+	// Format tables nicer (bootstrap). Force auto-width (default is 100%)
+	return '<table class="table table-striped table-bordered" style="width: auto;">';
+}
+
 // Initialise markdown editors on page
 document.addEventListener("DOMContentLoaded", function() {
-  var markdownEditors = Array.prototype.slice.call(document.querySelectorAll('.markdown-editor'));
+	var markdownEditors = Array.prototype.slice.call(document.querySelectorAll('.markdown-editor'));
 
-  markdownEditors.forEach(function (markdownEditor) {
-    var fieldName = markdownEditor.getAttribute('data-field-name');
+	markdownEditors.forEach(function (markdownEditor) {
+		var fieldName = markdownEditor.getAttribute('data-field-name');
 
-    var previewTabSelector = '#' + fieldName + '-preview-tab';
-    var targetSelector = '#' + fieldName + '-markdown-target';
-    var sourceSelector = markdownEditor.querySelector('.markdown-source');
+		var previewTabSelector = '#' + fieldName + '-preview-tab';
+		var targetSelector = '#' + fieldName + '-markdown-target';
+		var sourceSelector = markdownEditor.querySelector('.markdown-source');
 
-    var previewTabEl = markdownEditor.querySelector(previewTabSelector);
-    var targetEl = markdownEditor.querySelector(targetSelector);
+		var previewTabEl = markdownEditor.querySelector(previewTabSelector);
+		var targetEl = markdownEditor.querySelector(targetSelector);
 
-    var reader = new commonmark.Parser({safe: true});
-    var writer = new commonmark.HtmlRenderer({safe: true, softbreak: '<br />'});
+		previewTabEl.addEventListener('click', function () {
+			var rendered = markdown.render(sourceSelector.value.trim());
+			targetEl.innerHTML = rendered;
+		});
+	});
+});
 
-    previewTabEl.addEventListener('click', function () {
-      var parsed = reader.parse(sourceSelector.value.trim());
-      targetEl.innerHTML = writer.render(parsed);
-    });
-  });
+// Render markdown from elements with "markdown-text" attribute
+document.addEventListener("DOMContentLoaded", function() {
+
+	var markdownTargets = document.querySelectorAll('[markdown-text]');
+	for (var target of markdownTargets) {
+		var rendered = markdown.render(target.innerHTML);
+		target.innerHTML = rendered;
+	}
 });
 
 //

--- a/nyaa/templates/_formhelpers.html
+++ b/nyaa/templates/_formhelpers.html
@@ -50,7 +50,25 @@
 		</ul>
 		<div class="tab-content">
 			<div role="tabpanel" class="tab-pane active" id="{{ field_name }}-tab" data-markdown-target="#{{ field_name }}-markdown-target">
-				{{ render_field(field, False, class_='form-control markdown-source') }}
+				{# Render this field manually, because we need to escape the inner text #}
+				<textarea class="form-control markdown-source" id="{{ field.id }}" name="{{ field.name }}">
+				{{- field.data | escape | replace('\r\n', '\n') | replace('\n', '&#10;'|safe) -}}
+				</textarea>
+				{% if field.errors %}
+					<div class="help-block">
+						{% if field.errors|length < 2 %}
+							{% for error in field.errors %}
+								{{ error }}
+							{% endfor %}
+						{% else %}
+							<ul>
+								{% for error in field.errors %}
+									<li>{{ error }}</li>
+								{% endfor %}
+							</ul>
+						{% endif %}
+					</div>
+				{% endif %}
 			</div>
 			<div role="tabpanel" class="tab-pane" id="{{ field_name }}-preview">
 				<div class="well" id="{{ field_name }}-markdown-target"></div>

--- a/nyaa/templates/_formhelpers.html
+++ b/nyaa/templates/_formhelpers.html
@@ -35,6 +35,7 @@
 {% endif %}
 	<div class="markdown-editor" id="{{ field_name }}-markdown-editor" data-field-name="{{ field_name }}">
 		{{ field.label(class='control-label') }}
+		<a href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet" class="small">Markdown supported</a>
 		<ul class="nav nav-tabs" role="tablist">
 			<li role="presentation" class="active">
 				<a href="#{{ field_name }}-tab" role="tab" data-toggle="tab">

--- a/nyaa/templates/_formhelpers.html
+++ b/nyaa/templates/_formhelpers.html
@@ -52,7 +52,7 @@
 			<div role="tabpanel" class="tab-pane active" id="{{ field_name }}-tab" data-markdown-target="#{{ field_name }}-markdown-target">
 				{# Render this field manually, because we need to escape the inner text #}
 				<textarea class="form-control markdown-source" id="{{ field.id }}" name="{{ field.name }}">
-				{{- field.data | escape | replace('\r\n', '\n') | replace('\n', '&#10;'|safe) -}}
+				{{- (field.data or "") | escape | replace('\r\n', '\n') | replace('\n', '&#10;'|safe) -}}
 				</textarea>
 				{% if field.errors %}
 					<div class="help-block">

--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -43,7 +43,7 @@
 		<!-- Core JavaScript -->
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.27.0/commonmark.min.js" integrity="sha256-10JreQhQG80GtKuzsioj0K46DlaB/CK/EG+NuG0q97E=" crossorigin="anonymous"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/markdown-it/8.3.1/markdown-it.min.js" integrity="sha256-3WZyZQOe+ql3pLo90lrkRtALrlniGdnf//gRpW0UQks=" crossorigin="anonymous"></script>
 		<!-- Modified to not apply border-radius to selectpickers and stuff so our navbar looks cool -->
 		<script src="{{ static_cachebuster('js/bootstrap-select.js') }}"></script>
 		<script src="{{ static_cachebuster('js/main.js') }}"></script>

--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -81,13 +81,13 @@
 </div>
 
 <div class="panel panel-default">
-	<div class="panel-body" id="torrent-description">
-		{% if torrent.description %}
+	<div markdown-text class="panel-body" id="torrent-description">
+		{%- if torrent.description -%}
 		{# Escape newlines into html entities because CF strips blank newlines #}
-		{{ torrent.description | escape | replace('\r\n', '\n') | replace('\n', '&#10;'|safe) }}
-		{% else %}
+		{{- torrent.description | escape | replace('\r\n', '\n') | replace('\n', '&#10;'|safe) -}}
+		{%- else -%}
 		#### No description.
-		{% endif%}
+		{%- endif -%}
 	</div>
 </div>
 
@@ -161,19 +161,12 @@
 				</div>
 				<div class="row">
 					{# Escape newlines into html entities because CF strips blank newlines #}
-					<div class="comment-content" id="torrent-comment{{ comment.id }}">{{ comment.text }}</div>
+					<div markdown-text class="comment-content" id="torrent-comment{{ comment.id }}">{{ comment.text }}</div>
 				</div>
 			</div>
 		</div>
 	</div>
-	<script type="text/javascript">
-		var target = document.getElementById('torrent-comment{{ comment.id }}');
-		var text = target.innerHTML;
-		var reader = new commonmark.Parser({safe: true});
-		var writer = new commonmark.HtmlRenderer({safe: true, softbreak: '<br />'});
-		var parsed = reader.parse(text.trim());
-		target.innerHTML = writer.render(parsed);
-	</script>
+
 	{% endfor %}
 	{% if comment_form %}
 	<form class="comment-box" method="POST">
@@ -206,14 +199,5 @@
 			</div>
 		</div>
 	</div>
-
-<script>
-	var target = document.getElementById('torrent-description');
-	var text = target.innerHTML;
-	var reader = new commonmark.Parser({safe: true});
-	var writer = new commonmark.HtmlRenderer({safe: true, softbreak: '<br />'});
-	var parsed = reader.parse(text.trim());
-	target.innerHTML = writer.render(parsed);
-</script>
 
 {% endblock %}


### PR DESCRIPTION
As stated in #215, the Commonmark implementation we use is strictly commonmark and lacks (mostly) tables.
This PR replaces Commonmark with [markdown-it](https://github.com/markdown-it/markdown-it) and adds some CSS-fixes to the tables.
Elements tagged with `markdown-text` are parsed and rendered on `DOMContentLoaded` instead of separate `<script>` tags for every element (most notably with comments).

Preview:
![image](https://cloud.githubusercontent.com/assets/6820963/26592828/a04da740-456a-11e7-81e1-f0ce6faf15f3.png)

Also escapes the description markdown in the editor just as is done on the torrent page (Cloudflare strips empty lines and in the editor, whitespaces is prepended to the lines)