### PR TITLE
Change label of button on edit page from "Edit" to "Save Changes"

### DIFF
--- a/nyaa/templates/edit.html
+++ b/nyaa/templates/edit.html
@@ -82,7 +82,7 @@
 
 	<div class="row">
 		<div class="form-group col-md-6">
-			<input type="submit" value="Edit" class="btn btn-primary">
+			<input type="submit" value="Save Changes" class="btn btn-primary">
 		</div>
 	</div>
 </form>


### PR DESCRIPTION
Small nitpick change.

"Edit" being the button that saves the edits might be a little confusing, whereas "Save Changes" is less ambiguous and more easily recognised.