### PR TITLE
Focus report reason text field when reporting

### DIFF
--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -216,4 +216,11 @@
 	target.innerHTML = writer.render(parsed);
 </script>
 
+<script>
+	// Focus the report text field once the modal is opened.
+	$('#reportModal').on('shown.bs.modal', function () {
+		$('#reason').focus();
+	})
+</script>
+
 {% endblock %}


### PR DESCRIPTION
A small convenience change which by sets the focus to the newly opened modal dialog's text field if the report button is hit.

This way, people can type away their gripes with the torrent without having to click into the text field first.

Not sure if this is the cleanest way to add some more JS for this.