### PR TITLE
Test using Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,29 @@ language: python
 
 python: "3.6"
 
-dist: xenial
-sudo: false
+dist: trusty
+sudo: required
 
 matrix:
   fast_finish: true
 
 cache: pip
 
-install: pip install --upgrade pycodestyle
+services:
+  mysql
 
-script: ./lint.sh --check
+before_install:
+  - mysql -u root -e 'CREATE DATABASE nyaav2 DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;'
+
+install:
+  - pip install -r requirements.txt
+  - sed "s/mysql:\/\/test:test123@/mysql:\/\/root:@/" config.example.py > config.py
+  - python db_create.py
+  - ./db_migrate.py stamp head
+
+script:
+  - python -m pytest tests/
+  - ./lint.sh --check
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -108,3 +108,8 @@ However, take note that binglog is not necessary for simple ES testing and devel
 
 You're done! The script should now be feeding updates from the database to Elasticsearch.   
 Take note, however, that the specified ES index refresh interval is 30 seconds, which may feel like a long time on local development. Feel free to adjust it or [poke Elasticsearch yourself!](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html)
+
+### Running Tests
+We have some basic tests that check if each page can render correctly. To run the tests:
+- Make sure that you are in the python virtual environment.
+- Run `python -m pytest tests/` while in the repository directory.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NyaaV2
+# NyaaV2 [![Build Status](https://travis-ci.org/nyaadevs/nyaa.svg?branch=master)](https://travis-ci.org/nyaadevs/nyaa)
 
 ## Setting up for development
 This project uses Python 3.6. There are features used that do not exist in 3.5, so make sure to use Python 3.6.   
@@ -9,6 +9,11 @@ It's not impossible to run Nyaa on Windows, but this guide doesn't focus on that
 - Before we get any deeper, remember to follow PEP8 style guidelines and run `./lint.sh` before committing.
     - You may also use `./lint.sh -c` to see a list of warnings/problems instead of having `lint.sh` making modifications for you
 - Other than PEP8, try to keep your code clean and easy to understand, as well. It's only polite!
+
+### Running Tests
+We have some basic tests that check if each page can render correctly. To run the tests:
+- Make sure that you are in the python virtual environment.
+- Run `python -m pytest tests/` while in the repository directory.
 
 ### Setting up Pyenv
 pyenv eases the use of different Python versions, and as not all Linux distros offer 3.6 packages, it's right up our alley.
@@ -108,8 +113,3 @@ However, take note that binglog is not necessary for simple ES testing and devel
 
 You're done! The script should now be feeding updates from the database to Elasticsearch.   
 Take note, however, that the specified ES index refresh interval is 30 seconds, which may feel like a long time on local development. Feel free to adjust it or [poke Elasticsearch yourself!](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html)
-
-### Running Tests
-We have some basic tests that check if each page can render correctly. To run the tests:
-- Make sure that you are in the python virtual environment.
-- Run `python -m pytest tests/` while in the repository directory.

--- a/lint.sh
+++ b/lint.sh
@@ -49,3 +49,5 @@ if [[ ${action} == check_lint ]]; then
     echo "The code requires some changes."
   fi
 fi
+
+if [[ ${result} -ne 0 ]]; then exit 1; fi

--- a/nyaa/__init__.py
+++ b/nyaa/__init__.py
@@ -70,4 +70,4 @@ assets = Environment(app)
 #             output='style.css', depends='**/*.scss')
 # assets.register('style_all', css)
 
-from nyaa import routes  # noqa
+from nyaa import routes  # noqa E402

--- a/nyaa/api_handler.py
+++ b/nyaa/api_handler.py
@@ -322,7 +322,11 @@ def v2_api_info(torrent_id_or_hash):
 
         'information': torrent.information,
         'description': torrent.description,
-        'stats': {'seeders': torrent.stats.seed_count, 'leechers': torrent.stats.leech_count, 'downloads': torrent.stats.download_count},
+        'stats': {
+            'seeders': torrent.stats.seed_count,
+            'leechers': torrent.stats.leech_count,
+            'downloads': torrent.stats.download_count
+        },
         'filesize': torrent.filesize,
         'files': files,
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,11 +28,14 @@ mysqlclient==1.3.10
 orderedset==2.0
 packaging==16.8
 passlib==1.7.1
+progressbar2==3.20.0
 progressbar33==2.4
+py==1.4.34
 pycodestyle==2.3.1
 pycparser==2.17
 PyMySQL==0.7.11
 pyparsing==2.2.0
+pytest==3.1.1
 python-dateutil==2.6.0
 python-editor==1.0.3
 python-utils==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,6 @@ mysqlclient==1.3.10
 orderedset==2.0
 packaging==16.8
 passlib==1.7.1
-progressbar2==3.20.0
 progressbar33==2.4
 py==1.4.34
 pycodestyle==2.3.1

--- a/tests/test_nyaa.py
+++ b/tests/test_nyaa.py
@@ -43,7 +43,7 @@ class NyaaTestCase(unittest.TestCase):
         rv = self.app.get('/login')
         assert b'Username or email address' in rv.data
 
-    def test_registry(self):
+    def test_registration_url(self):
         rv = self.app.get('/register')
         assert b'Username' in rv.data
         assert b'Password' in rv.data

--- a/tests/test_nyaa.py
+++ b/tests/test_nyaa.py
@@ -17,7 +17,7 @@ class NyaaTestCase(unittest.TestCase):
 		os.close(self.db)
 		os.unlink(nyaa.app.config['DATABASE'])
 
-	def test_empty_db(self):
+	def test_index_url(self):
 		rv = self.app.get('/')
 		assert b'Browse :: Nyaa' in rv.data
 		assert b'Guest' in rv.data

--- a/tests/test_nyaa.py
+++ b/tests/test_nyaa.py
@@ -1,0 +1,53 @@
+import os
+import unittest
+import tempfile
+import nyaa
+
+
+class NyaaTestCase(unittest.TestCase):
+
+	def setUp(self):
+		self.db, nyaa.app.config['DATABASE'] = tempfile.mkstemp()
+		nyaa.app.config['TESTING'] = True
+		self.app = nyaa.app.test_client()
+		with nyaa.app.app_context():
+			nyaa.db.create_all()
+
+	def tearDown(self):
+		os.close(self.db)
+		os.unlink(nyaa.app.config['DATABASE'])
+
+	def test_empty_db(self):
+		rv = self.app.get('/')
+		assert b'Browse :: Nyaa' in rv.data
+		assert b'Guest' in rv.data
+
+	def test_upload_url(self):
+		rv = self.app.get('/upload')
+		assert b'Upload Torrent' in rv.data
+		assert b'You are not logged in, and are uploading anonymously.' in rv.data
+
+	def test_rules_url(self):
+		rv = self.app.get('/rules')
+		assert b'Site Rules' in rv.data
+
+	def test_help_url(self):
+		rv = self.app.get('/help')
+		assert b'Using the Site' in rv.data
+
+	def test_rss_url(self):
+		rv = self.app.get('/?page=rss')
+		assert b'/xmlns/nyaa' in rv.data
+
+	def test_login_url(self):
+		rv = self.app.get('/login')
+		assert b'Username or email address' in rv.data
+
+	def test_registry(self):
+		rv = self.app.get('/register')
+		assert b'Username' in rv.data
+		assert b'Password' in rv.data
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/test_nyaa.py
+++ b/tests/test_nyaa.py
@@ -6,48 +6,48 @@ import nyaa
 
 class NyaaTestCase(unittest.TestCase):
 
-	def setUp(self):
-		self.db, nyaa.app.config['DATABASE'] = tempfile.mkstemp()
-		nyaa.app.config['TESTING'] = True
-		self.app = nyaa.app.test_client()
-		with nyaa.app.app_context():
-			nyaa.db.create_all()
+    def setUp(self):
+        self.db, nyaa.app.config['DATABASE'] = tempfile.mkstemp()
+        nyaa.app.config['TESTING'] = True
+        self.app = nyaa.app.test_client()
+        with nyaa.app.app_context():
+            nyaa.db.create_all()
 
-	def tearDown(self):
-		os.close(self.db)
-		os.unlink(nyaa.app.config['DATABASE'])
+    def tearDown(self):
+        os.close(self.db)
+        os.unlink(nyaa.app.config['DATABASE'])
 
-	def test_index_url(self):
-		rv = self.app.get('/')
-		assert b'Browse :: Nyaa' in rv.data
-		assert b'Guest' in rv.data
+    def test_index_url(self):
+        rv = self.app.get('/')
+        assert b'Browse :: Nyaa' in rv.data
+        assert b'Guest' in rv.data
 
-	def test_upload_url(self):
-		rv = self.app.get('/upload')
-		assert b'Upload Torrent' in rv.data
-		assert b'You are not logged in, and are uploading anonymously.' in rv.data
+    def test_upload_url(self):
+        rv = self.app.get('/upload')
+        assert b'Upload Torrent' in rv.data
+        assert b'You are not logged in, and are uploading anonymously.' in rv.data
 
-	def test_rules_url(self):
-		rv = self.app.get('/rules')
-		assert b'Site Rules' in rv.data
+    def test_rules_url(self):
+        rv = self.app.get('/rules')
+        assert b'Site Rules' in rv.data
 
-	def test_help_url(self):
-		rv = self.app.get('/help')
-		assert b'Using the Site' in rv.data
+    def test_help_url(self):
+        rv = self.app.get('/help')
+        assert b'Using the Site' in rv.data
 
-	def test_rss_url(self):
-		rv = self.app.get('/?page=rss')
-		assert b'/xmlns/nyaa' in rv.data
+    def test_rss_url(self):
+        rv = self.app.get('/?page=rss')
+        assert b'/xmlns/nyaa' in rv.data
 
-	def test_login_url(self):
-		rv = self.app.get('/login')
-		assert b'Username or email address' in rv.data
+    def test_login_url(self):
+        rv = self.app.get('/login')
+        assert b'Username or email address' in rv.data
 
-	def test_registry(self):
-		rv = self.app.get('/register')
-		assert b'Username' in rv.data
-		assert b'Password' in rv.data
+    def test_registry(self):
+        rv = self.app.get('/register')
+        assert b'Username' in rv.data
+        assert b'Password' in rv.data
 
 
 if __name__ == '__main__':
-	unittest.main()
+    unittest.main()

--- a/utils/api_info.py
+++ b/utils/api_info.py
@@ -112,7 +112,8 @@ if __name__ == '__main__':
             exit(1)
         else:
             formatted_filesize = easy_file_size(response.get('filesize', 0))
-            flag_info = ', '.join(n+': '+_as_yes_no(response['is_'+n.lower()]) for n in FLAG_NAMES)
+            flag_info = ', '.join(
+                n + ': ' + _as_yes_no(response['is_' + n.lower()]) for n in FLAG_NAMES)
 
             info_str = INFO_TEMPLATE.format(formatted_filesize=formatted_filesize,
                                             flag_info=flag_info, **response)


### PR DESCRIPTION
Based on @nathancyam's work from #121 

Had to drop Travis' container-based infrastructure and enable sudo, because some things are broken.
It was either a too old MySQL version to support `FULLTEXTSEARCH`, MariaDB not being able to install, or not being able to install `mysqlclient` module (Python) because it fails to build it...
It's not that big of a deal, it seems. Perhaps a little bit slower.

Also, a fix to the lint script's exit code (Travis builds always passing)

A new bash script with subcommands (`./dev.sh lint [-c]`,`./dev.sh test`) might be a good idea