### PR TITLE
Load categories from DB

### DIFF
--- a/db_create.py
+++ b/db_create.py
@@ -7,27 +7,87 @@ from nyaa.extensions import db
 app = create_app('config')
 
 NYAA_CATEGORIES = [
-    ('Anime', ['Anime Music Video', 'English-translated', 'Non-English-translated', 'Raw']),
-    ('Audio', ['Lossless', 'Lossy']),
-    ('Literature', ['English-translated', 'Non-English-translated', 'Raw']),
-    ('Live Action', ['English-translated', 'Idol/Promotional Video', 'Non-English-translated', 'Raw']),
-    ('Pictures', ['Graphics', 'Photos']),
-    ('Software', ['Applications', 'Games']),
+    {
+        'name': 'Anime',
+        'subcats': [
+            {'name': 'Anime Music Video', 'title': 'AMV'},
+            {'name': 'English-translated', 'title': 'English'},
+            {'name': 'Non-English-translated', 'title': 'Non-English'},
+            {'name': 'Raw'},
+        ]
+    },
+    {
+        'name': 'Audio',
+        'subcats': [
+            {'name': 'Lossless'},
+            {'name': 'Lossy'}
+        ]
+    },
+    {
+        'name': 'Literature',
+        'subcats': [
+            {'name': 'English-translated', 'title': 'English'},
+            {'name': 'Non-English-translated', 'title': 'Non-English'},
+            {'name': 'Raw'},
+        ]
+    },
+    {
+        'name': 'Live Action',
+        'subcats': [
+            {'name': 'English-translated', 'title': 'English'},
+            {'name': 'Idol/Promotional Video', 'title': 'Idol/PV'},
+            {'name': 'Non-English-translated', 'title': 'Non-English'},
+            {'name': 'Raw'},
+        ]
+    },
+    {
+        'name': 'Pictures',
+        'subcats': [
+            {'name': 'Graphics'},
+            {'name': 'Photos'}
+        ]
+    },
+    {
+        'name': 'Software',
+        'subcats': [
+            {'name': 'Applications', 'title': 'Apps'},
+            {'name': 'Games'}
+        ]
+    },
 ]
 
-
 SUKEBEI_CATEGORIES = [
-    ('Art', ['Anime', 'Doujinshi', 'Games', 'Manga', 'Pictures']),
-    ('Real Life', ['Photobooks / Pictures', 'Videos']),
+    {
+        'name': 'Art',
+        'subcats': [
+            {'name': 'Anime'},
+            {'name': 'Doujinshi'},
+            {'name': 'Games'},
+            {'name': 'Manga'},
+            {'name': 'Pictures'},
+            {'name': 'Audio'},
+        ]
+    },
+    {
+        'name': 'Real Life',
+        'subcats': [
+            {'name': 'Photobooks and Pictures', 'title': 'Pictures'},
+            {'name': 'Videos'},
+        ]
+    },
 ]
 
 
 def add_categories(categories, main_class, sub_class):
-    for main_cat_name, sub_cat_names in categories:
-        main_cat = main_class(name=main_cat_name)
-        for i, sub_cat_name in enumerate(sub_cat_names):
-            # Composite keys can't autoincrement, set sub_cat id manually (1-index)
-            sub_cat = sub_class(id=i+1, name=sub_cat_name, main_category=main_cat)
+    for main_cat in categories:
+        sub_categories = main_cat.get('subcats', [])
+        main_cat = main_class(name=main_cat['name'],
+                              title=main_cat.get('title', main_cat['name']))
+        for i, sub_cat in enumerate(sub_categories):
+            # Composite keys can't autoincrement, set sub_cat id manually (index+1)
+            sub_cat = sub_class(id=i+1, name=sub_cat['name'],
+                                title=sub_cat.get('title', sub_cat['name']),
+                                main_category=main_cat)
         db.session.add(main_cat)
 
 

--- a/migrations/versions/4dcf40477f0a_add_title_column_to_category_tables.py
+++ b/migrations/versions/4dcf40477f0a_add_title_column_to_category_tables.py
@@ -1,0 +1,45 @@
+"""Add title column to category tables
+
+Revision ID: 4dcf40477f0a
+Revises: ffd23e570f92
+Create Date: 2017-07-30 22:57:46.524459
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '4dcf40477f0a'
+down_revision = 'ffd23e570f92'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('nyaa_main_categories', sa.Column('title', sa.String(length=64), nullable=False))
+    op.add_column('nyaa_sub_categories', sa.Column('title', sa.String(length=64), nullable=False))
+    op.add_column('sukebei_main_categories', sa.Column('title', sa.String(length=64), nullable=False))
+    op.add_column('sukebei_sub_categories', sa.Column('title', sa.String(length=64), nullable=False))
+
+    # Insert values for the new title column
+    for table_name in ('nyaa_main', 'nyaa_sub', 'sukebei_main', 'sukebei_sub'):
+        # Copy name to title for starters
+        update = 'UPDATE {t}_categories'.format(t=table_name)
+        op.execute(update + ' SET title = name;'.format(t=table_name))
+
+        # Only need to do this for sub-categories
+        if table_name in ('nyaa_sub', 'sukebei_sub'):
+            op.execute(update + ' SET title = "English" WHERE name = "English-translated";')
+            op.execute(update + ' SET title = "Non-English" WHERE name = "Non-English-translated";')
+            op.execute(update + ' SET title = "AMV" WHERE name = "Anime Music Video";')
+            op.execute(update + ' SET title = "Idol/PV" WHERE name = "Idol/Promotional Video";')
+            op.execute(update + ' SET title = "Apps" WHERE name = "Applications";')
+            op.execute(update + ' SET title = "Pictures" WHERE name LIKE "Photobooks%Pictures";')
+
+
+def downgrade():
+    op.drop_column('sukebei_sub_categories', 'title')
+    op.drop_column('sukebei_main_categories', 'title')
+    op.drop_column('nyaa_sub_categories', 'title')
+    op.drop_column('nyaa_main_categories', 'title')

--- a/nyaa/backend.py
+++ b/nyaa/backend.py
@@ -13,19 +13,6 @@ from nyaa.extensions import db
 app = flask.current_app
 
 
-@utils.cached_function
-def get_category_id_map():
-    ''' Reads database for categories and turns them into a dict with
-        ids as keys and name list as the value, ala
-        {'1_0': ['Anime'], '1_2': ['Anime', 'English-translated'], ...} '''
-    cat_id_map = {}
-    for main_cat in models.MainCategory.query:
-        cat_id_map[main_cat.id_as_string] = [main_cat.name]
-        for sub_cat in main_cat.sub_categories:
-            cat_id_map[sub_cat.id_as_string] = [main_cat.name, sub_cat.name]
-    return cat_id_map
-
-
 def _replace_utf8_values(dict_or_list):
     ''' Will replace 'property' with 'property.utf-8' and remove latter if it exists.
         Thanks, bitcomet! :/ '''

--- a/nyaa/models.py
+++ b/nyaa/models.py
@@ -366,6 +366,7 @@ class MainCategoryBase(DeclarativeHelperBase):
 
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(length=64), nullable=False)
+    title = db.Column(db.String(length=64), nullable=False)
 
     @declarative.declared_attr
     def sub_categories(cls):
@@ -391,13 +392,13 @@ class SubCategoryBase(DeclarativeHelperBase):
     __tablename_base__ = 'sub_categories'
 
     id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(length=64), nullable=False)
+    title = db.Column(db.String(length=64), nullable=False)
 
     @declarative.declared_attr
     def main_category_id(cls):
         fk = db.ForeignKey(cls._table_prefix('main_categories.id'))
         return db.Column(db.Integer, fk, primary_key=True)
-
-    name = db.Column(db.String(length=64), nullable=False)
 
     @declarative.declared_attr
     def main_category(cls):

--- a/nyaa/template_utils.py
+++ b/nyaa/template_utils.py
@@ -5,6 +5,7 @@ from email.utils import formatdate
 from urllib.parse import urlencode
 
 import flask
+from markupsafe import Markup
 from werkzeug.urls import url_encode
 
 from nyaa import models
@@ -158,3 +159,19 @@ def timesince(dt, default='just now'):
                 return '%d %s ago' % (period, singular if int(period) == 1 else plural)
 
     return default
+
+
+@bp.app_template_filter('tabindent')
+def indent_with_tabs(s, tabs=1, indentfirst=False):
+    """ Return a copy of the passed string, each line indented by
+        1 tab. The first line is not indented. If you want to
+        change the number of tabs or indent the first line too
+        you can pass additional parameters to the filter. """
+
+    # Adapted from `jinja2.filters.do_indent` [Jinja2==2.9.6]
+    # Can't use `do_indent` because it causes text to be marked unsafe an escapes it.
+    indention = Markup(u'\t' * tabs)
+    rv = (Markup(u'\n') + indention).join(s.splitlines())
+    if indentfirst:
+        rv = indention + rv
+    return rv

--- a/nyaa/templates/_formhelpers.html
+++ b/nyaa/templates/_formhelpers.html
@@ -139,3 +139,17 @@
 		{% endif %}
 	</div>
 {% endmacro %}
+
+{% macro render_category_options(search, use_title=True) %}
+{% set all_cats = search is defined and search.category == '0_0' or not search %}
+<option value="0_0" title="All categories"{% if all_cats %} selected{% endif %}>
+	{{- 'All categories' -}}
+</option>
+{% for cat_id, cat_names in get_category_id_map().items() %}
+<option value="{{ cat_id }}" title="{{ cat_names['title' if use_title else 'name'] }}"
+		{%- if search is defined and search.category == cat_id %} selected{% endif -%}
+>
+	{{- ('- ' if not cat_id.endswith('_0') else '') + cat_names['name'] -}}
+</option>
+{% endfor %}
+{% endmacro %}

--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -1,3 +1,4 @@
+{% from '_formhelpers.html' import render_category_options %}
 <!DOCTYPE html>
 <html lang="en">
 	<head>
@@ -169,47 +170,6 @@
 						</li>
 						{% endif %}
 					</ul>
-					{% set nyaa_cats = [('1_0', 'Anime', 'Anime'),
-						('1_1', '- Anime Music Video', 'Anime - AMV'),
-						('1_2', '- English-translated', 'Anime - English'),
-						('1_3', '- Non-English-translated', 'Anime - Non-English'),
-						('1_4', '- Raw', 'Anime - Raw'),
-						('2_0', 'Audio', 'Audio'),
-						('2_1', '- Lossless', 'Audio - Lossless'),
-						('2_2', '- Lossy', 'Audio - Lossy'),
-						('3_0', 'Literature', 'Literature'),
-						('3_1', '- English-translated', 'Literature - English'),
-						('3_2', '- Non-English-translated', 'Literature - Non-English'),
-						('3_3', '- Raw', 'Literature - Raw'),
-						('4_0', 'Live Action', 'Live Action'),
-						('4_1', '- English-translated', 'Live Action - English'),
-						('4_2', '- Idol/Promotional Video', 'Live Action - Idol/PV'),
-						('4_3', '- Non-English-translated', 'Live Action - Non-English'),
-						('4_4', '- Raw', 'Live Action - Raw'),
-						('5_0', 'Pictures', 'Pictures'),
-						('5_1', '- Graphics', 'Pictures - Graphics'),
-						('5_2', '- Photos', 'Pictures - Photos'),
-						('6_0', 'Software', 'Software'),
-						('6_1', '- Applications', 'Software - Apps'),
-						('6_2', '- Games', 'Software - Games')]
-					%}
-		
-					{% set suke_cats = [('1_0', 'Art', 'Art'),
-						('1_1', '- Anime', 'Art - Anime'),
-						('1_2', '- Doujinshi', 'Art - Doujinshi'),
-						('1_3', '- Games', 'Art - Games'),
-						('1_4', '- Manga', 'Art - Manga'),
-						('1_5', '- Pictures', 'Art - Pictures'),
-						('2_0', 'Real Life', 'Real Life'),
-						('2_1', '- Photobooks and Pictures', 'Real Life - Pictures'),
-						('2_2', '- Videos', 'Real Life - Videos')]
-					%}
-
-					{% if config.SITE_FLAVOR == 'nyaa' %}
-						{% set used_cats = nyaa_cats %}
-					{% elif config.SITE_FLAVOR == 'sukebei' %}
-						{% set used_cats = suke_cats %}
-					{% endif %}
 
 					<div class="search-container visible-xs visible-sm">
 					{# The mobile menu #}
@@ -231,14 +191,7 @@
 							<br>
 	
 							<select class="form-control" title="Category" data-width="200px" name="c">
-								<option value="0_0" title="All categories" {% if search is defined and search["category"] == "0_0" %}selected{% else %}selected{% endif %}>
-									All categories
-								</option>
-								{% for cat_id, cat_name, cat_title in used_cats %}
-								<option value="{{ cat_id }}" title="{{ cat_title }}" {% if search is defined and search.category == cat_id %}selected{% endif %}>
-									{{ cat_name }}
-								</option>
-								{% endfor %}
+								{{ render_category_options(search) }}
 							</select>
 	
 							<br>
@@ -270,25 +223,11 @@
 								{# XXX Search breaks with multiple fields with the same name: default to the shorter one so we don't break visuals. This is a hack! #}
 								{# 
 								<select class="selectpicker show-tick visible-lg" title="Category" data-width="200px" name="c">
-									<option value="0_0" title="All categories" {% if search is defined and search["category"] == "0_0" %}selected{% else %}selected{% endif %}>
-										All categories
-									</option>
-									{% for cat_id, cat_name, cat_title in used_cats %}
-									<option value="{{ cat_id }}" title="{{ cat_title }}" {% if search is defined and search.category == cat_id %}selected{% endif %}>
-										{{ cat_name }}
-									</option>
-									{% endfor %}
+									{{ render_category_options(search) }}
 								</select> 
 								#}
 								<select class="selectpicker show-tick" title="Category" data-width="130px" name="c">
-									<option value="0_0" title="All categories" {% if search is defined and search["category"] == "0_0" %}selected{% else %}selected{% endif %}>
-										All categories
-									</option>
-									{% for cat_id, cat_name, cat_title in used_cats %}
-									<option value="{{ cat_id }}" title="{{ cat_title }}" {% if search is defined and search.category == cat_id %}selected{% endif %}>
-										{{ cat_name }}
-									</option>
-									{% endfor %}
+									{{ render_category_options(search) }}
 								</select>
 							</div>
 							<input type="text" class="form-control search-bar" name="q" placeholder="{{ search_placeholder }}" value="{{ search['term'] if search is defined else '' }}" />

--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -191,7 +191,7 @@
 							<br>
 	
 							<select class="form-control" title="Category" data-width="200px" name="c">
-								{{ render_category_options(search) }}
+								{{ render_category_options(search) | tabindent(8) }}
 							</select>
 	
 							<br>
@@ -223,11 +223,11 @@
 								{# XXX Search breaks with multiple fields with the same name: default to the shorter one so we don't break visuals. This is a hack! #}
 								{# 
 								<select class="selectpicker show-tick visible-lg" title="Category" data-width="200px" name="c">
-									{{ render_category_options(search) }}
+									{{ render_category_options(search) | tabindent(9) }}
 								</select> 
 								#}
 								<select class="selectpicker show-tick" title="Category" data-width="130px" name="c">
-									{{ render_category_options(search) }}
+									{{ render_category_options(search) | tabindent(9) }}
 								</select>
 							</div>
 							<input type="text" class="form-control search-bar" name="q" placeholder="{{ search_placeholder }}" value="{{ search['term'] if search is defined else '' }}" />

--- a/nyaa/views/torrents.py
+++ b/nyaa/views/torrents.py
@@ -250,17 +250,14 @@ def upload():
 
 @cached_function
 def _create_upload_category_choices():
-    ''' Turns categories in the database into a list of (id, name)s '''
+    """ Turns categories in the database into a list of (id, name, bool:is_main_category)s """
     choices = [('', '[Select a category]')]
     id_map = get_category_id_map()
 
     for key in sorted(id_map.keys()):
         cat_names = id_map[key]
         is_main_cat = key.endswith('_0')
-
-        # cat_name = is_main_cat and cat_names[0] or (' - ' + cat_names[1])
-        cat_name = ' - '.join(cat_names)
-        choices.append((key, cat_name, is_main_cat))
+        choices.append((key, cat_names['name'], is_main_cat))
     return choices
 
 

--- a/nyaa/views/torrents.py
+++ b/nyaa/views/torrents.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import joinedload
 
 from nyaa import backend, forms, models, torrents
 from nyaa.extensions import db
+from nyaa.template_utils import get_category_id_map
 from nyaa.utils import cached_function
 
 app = flask.current_app
@@ -251,7 +252,7 @@ def upload():
 def _create_upload_category_choices():
     ''' Turns categories in the database into a list of (id, name)s '''
     choices = [('', '[Select a category]')]
-    id_map = backend.get_category_id_map()
+    id_map = get_category_id_map()
 
     for key in sorted(id_map.keys()):
         cat_names = id_map[key]

--- a/tests/test_template_utils.py
+++ b/tests/test_template_utils.py
@@ -1,11 +1,13 @@
-import unittest
 import datetime
-
+import unittest
 from email.utils import formatdate
 
-from tests import NyaaTestCase
+from markupsafe import Markup
+
 from nyaa.template_utils import (_jinja2_filter_rfc822, _jinja2_filter_rfc822_es, get_utc_timestamp,
-                                 get_display_time, timesince, filter_truthy, category_name)
+                                 get_display_time, timesince, filter_truthy, category_name,
+                                 indent_with_tabs)
+from tests import NyaaTestCase
 
 
 class TestTemplateUtils(NyaaTestCase):
@@ -54,6 +56,12 @@ class TestTemplateUtils(NyaaTestCase):
             timesince(now - datetime.timedelta(hours=2, minutes=38, seconds=51)), '2 hours ago')
         bigger = now - datetime.timedelta(days=3)
         self.assertEqual(timesince(bigger), bigger.strftime('%Y-%m-%d %H:%M UTC'))
+
+    def test_indent_with_tabs(self):
+        text = '\n'.join(['', 'foo bar', ''])
+        self.assertEquals(indent_with_tabs(text), Markup('\n\tfoo bar'))
+        self.assertEquals(indent_with_tabs(text, 4), Markup('\n\t\t\t\tfoo bar'))
+        self.assertEquals(indent_with_tabs(text, 2, True), Markup('\t\t\n\t\tfoo bar'))
 
     @unittest.skip('Not yet implemented')
     def test_static_cachebuster(self):


### PR DESCRIPTION
Load the categories from the database for the search boxes in `layout.html`,
by adding `title` to the database, and using the [`get_category_id_map()`](https://github.com/sharkykh/nyaa/blob/50482340fb3696625053e7142b591aa61c0ba33d/nyaa/routes.py#L149-L168) cached function as a global template.
Note: DB changes in this PR.

* This **does not change** anything visibly in the front-end UI.
* **I advise to wait, and merge other `layout.html`-changing PRs before merging this.
_Especially #283 (merged) and #180_**

Additions:
- [x] `tabindent` template filter, that indents the code with tabs (only for `{{ code }}` statements)

**Update 2017-08-01:**
 * Rebased against master@[`87dd95f`](https://github.com/nyaadevs/nyaa/tree/87dd95f1e023416481a9c597b424830df6fe2614)
 * **Todo:** Update DB migration script to revise current head (ffd23e570f92)