### PR TITLE
[Restructure routes 1] Import sorting + Static pages

### DIFF
--- a/nyaa/routes.py
+++ b/nyaa/routes.py
@@ -1,4 +1,3 @@
-import base64
 import json
 import math
 import os.path
@@ -20,7 +19,7 @@ import config
 from itsdangerous import BadSignature, URLSafeSerializer
 from sqlalchemy.orm import joinedload
 
-from nyaa import api_handler, app, backend, bencode, db, forms, models, torrents, utils
+from nyaa import api_handler, app, backend, db, forms, models, torrents, utils
 from nyaa.search import search_db, search_elastic
 
 DEBUG_API = False

--- a/nyaa/routes.py
+++ b/nyaa/routes.py
@@ -19,7 +19,7 @@ import config
 from itsdangerous import BadSignature, URLSafeSerializer
 from sqlalchemy.orm import joinedload
 
-from nyaa import api_handler, app, backend, db, forms, models, torrents, utils
+from nyaa import api_handler, app, backend, db, forms, models, torrents, utils, views
 from nyaa.search import search_db, search_elastic
 
 DEBUG_API = False
@@ -450,11 +450,6 @@ def render_rss(label, query, use_elastic, magnet_links=False):
     # Cache for an hour
     response.headers['Cache-Control'] = 'max-age={}'.format(1 * 5 * 60)
     return response
-
-
-# @app.route('/about', methods=['GET'])
-# def about():
-    # return flask.render_template('about.html')
 
 
 @app.route('/login', methods=['GET', 'POST'])
@@ -1001,24 +996,17 @@ def timesince(dt, default='just now'):
 
     return default
 
-# #################################### STATIC PAGES ####################################
+
+# #################################### BLUEPRINTS ####################################
+
+def register_blueprints(flask_app):
+    """ Register the blueprints using the flask_app object """
+
+    # API routes
+    flask_app.register_blueprint(api_handler.api_blueprint, url_prefix='/api')
+    # Site routes
+    flask_app.register_blueprint(views.site_bp)
 
 
-@app.route('/rules', methods=['GET'])
-def site_rules():
-    return flask.render_template('rules.html')
-
-
-@app.route('/help', methods=['GET'])
-def site_help():
-    return flask.render_template('help.html')
-
-
-@app.route('/xmlns/nyaa', methods=['GET'])
-def xmlns_nyaa():
-    return flask.render_template('xmlns.html')
-
-
-# #################################### API ROUTES ####################################
-
-app.register_blueprint(api_handler.api_blueprint, url_prefix='/api')
+# When done, this can be moved to nyaa/__init__.py instead of importing this file
+register_blueprints(app)

--- a/nyaa/routes.py
+++ b/nyaa/routes.py
@@ -1,33 +1,27 @@
-import flask
-from werkzeug.datastructures import CombinedMultiDict
-from nyaa import app, db
-from nyaa import models, forms
-from nyaa import bencode, utils
-from nyaa import torrents
-from nyaa import backend
-from nyaa import api_handler
-from nyaa.search import search_elastic, search_db
-from sqlalchemy.orm import joinedload
-import config
-
-import re
-import json
-from datetime import datetime, timedelta
-from ipaddress import ip_address
-import os.path
 import base64
-from urllib.parse import quote
+import json
 import math
-from werkzeug import url_encode
-
-from itsdangerous import URLSafeSerializer, BadSignature
-
+import os.path
+import re
 import smtplib
+from datetime import datetime, timedelta
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.utils import formatdate
+from ipaddress import ip_address
+from urllib.parse import quote
 
+import flask
 from flask_paginate import Pagination
+from werkzeug import url_encode
+from werkzeug.datastructures import CombinedMultiDict
+
+import config
+from itsdangerous import BadSignature, URLSafeSerializer
+from sqlalchemy.orm import joinedload
+
+from nyaa import api_handler, app, backend, bencode, db, forms, models, torrents, utils
+from nyaa.search import search_db, search_elastic
 
 DEBUG_API = False
 DEFAULT_MAX_SEARCH_RESULT = 1000

--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -78,8 +78,8 @@
 								<span class="caret"></span>
 							</a>
 							<ul class="dropdown-menu">
-								<li {% if request.path == url_for('site_rules') %}class="active"{% endif %}><a href="{{ url_for('site_rules') }}">Rules</a></li>
-								<li {% if request.path == url_for('site_help') %}class="active"{% endif %}><a href="{{ url_for('site_help') }}">Help</a></li>
+								<li {% if request.path == url_for('site.rules') %}class="active"{% endif %}><a href="{{ url_for('site.rules') }}">Rules</a></li>
+								<li {% if request.path == url_for('site.help') %}class="active"{% endif %}><a href="{{ url_for('site.help') }}">Help</a></li>
 							</ul>
 						</li>
 						<li><a href="{% if rss_filter %}{{ url_for('home', page='rss', **rss_filter) }}{% else %}{{ url_for('home', page='rss') }}{% endif %}">RSS</a></li>

--- a/nyaa/templates/rss.xml
+++ b/nyaa/templates/rss.xml
@@ -1,4 +1,4 @@
-<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:nyaa="{{ url_for('xmlns_nyaa', _external=True) }}" version="2.0">
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:nyaa="{{ url_for('site.xmlns_nyaa', _external=True) }}" version="2.0">
 	<channel>
 		<title>{{ config.SITE_NAME }} Torrent File RSS</title>
 		<description>RSS Feed for {{ term }}</description>

--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -191,7 +191,7 @@
 			<div class="modal-body">
 				<div class="alert alert-warning" role="alert">
 					Before submitting a report, please check that the torrent
-					actually breaks <a href="{{ url_for('site_rules') }}">the
+					actually breaks <a href="{{ url_for('site.rules') }}">the
 					rules</a>. Useless reports like "download is slow" or
 					"thanks" can get you banned from the site.
 				</div>

--- a/nyaa/views/__init__.py
+++ b/nyaa/views/__init__.py
@@ -1,0 +1,5 @@
+from nyaa.views import (
+    site,
+)
+
+site_bp = site.bp

--- a/nyaa/views/site.py
+++ b/nyaa/views/site.py
@@ -1,0 +1,23 @@
+import flask
+
+bp = flask.Blueprint('site', __name__)
+
+
+# @bp.route('/about', methods=['GET'])
+# def about():
+#     return flask.render_template('about.html')
+
+
+@bp.route('/rules', methods=['GET'])
+def rules():
+    return flask.render_template('rules.html')
+
+
+@bp.route('/help', methods=['GET'])
+def help():
+    return flask.render_template('help.html')
+
+
+@bp.route('/xmlns/nyaa', methods=['GET'])
+def xmlns_nyaa():
+    return flask.render_template('xmlns.html')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[isort]
+line_length = 100
+default_section = THIRDPARTY
+known_first_party = nyaa
+known_flask = flask, flask_wtf, flask_paginate, jinja2, werkzeug
+sections = STDLIB,FLASK,THIRDPARTY,FIRSTPARTY,LOCALFOLDER


### PR DESCRIPTION
* Start sorting imports (one by one for now) - `isort path/to/file.py` (requires [`isort`](https://pypi.python.org/pypi/isort) to be installed in virtual environment)
* Start restructuring the `routes.py` file into smaller blueprint files.
  This is a suggestion... There might be a better way to go about this.
  Starting small, with the static routes:
    * /about (commented out)
    * /help
    * /rules
    * /xmlns/nyaa