### PR TITLE
Add proper shebang line to run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,2 +1,3 @@
+#!/usr/bin/env python3
 from nyaa import app
 app.run(host='0.0.0.0', port=5500, debug=True)


### PR DESCRIPTION
Without a shebang, the shell tries to interpret the file as a shell script if you issue the `./run.py` command; setting `chmod +x` on the file without a proper shebang is useless.