### PR TITLE
Frontend report improvements

### DIFF
--- a/nyaa/static/css/main.css
+++ b/nyaa/static/css/main.css
@@ -411,3 +411,7 @@ h6:hover .header-anchor {
 		margin-top: auto;
 	}
 }
+
+table.table > tbody > tr.reports-row > td {
+	vertical-align: middle;
+}

--- a/nyaa/static/css/main.css
+++ b/nyaa/static/css/main.css
@@ -415,3 +415,7 @@ h6:hover .header-anchor {
 table.table > tbody > tr.reports-row > td {
 	vertical-align: middle;
 }
+
+td.report-action-column {
+	min-width: 150px;
+}

--- a/nyaa/templates/reports.html
+++ b/nyaa/templates/reports.html
@@ -2,7 +2,7 @@
 {% block title %}Reports :: {{ config.SITE_NAME }}{% endblock %}
 {% block body %}
 {% from "_formhelpers.html" import render_field %}
-	<div class="table-responsive">
+	<div class="table">
 		<table class="table table-bordered table-hover table-striped table-condensed">
 			<thead>
 			<tr>
@@ -37,7 +37,7 @@
 				</td>
 				<td>{{ report.reason }}</td>
 				<td>{{ report.created_time }}</td>
-				<td style="min-width: 150px">
+				<td class="report-action-column">
 					<form method="post">
 						{{ report_action.csrf_token }}
 						{{ report_action.torrent(value=report.torrent.id) }}

--- a/nyaa/templates/reports.html
+++ b/nyaa/templates/reports.html
@@ -3,7 +3,7 @@
 {% block body %}
 {% from "_formhelpers.html" import render_field %}
 	<div class="table-responsive">
-		<table class="table table-bordered table-hover table-striped">
+		<table class="table table-bordered table-hover table-striped table-condensed">
 			<thead>
 			<tr>
 				<th>#</th>
@@ -16,7 +16,7 @@
 			</thead>
 			<tbody>
 			{% for report in reports.items %}
-			<tr>
+			<tr class="reports-row">
 				<td>{{ report.id }}</td>
 				<td>
 					<a href="{{ url_for('view_user', user_name=report.user.username) }}">{{ report.user.username }}</a>
@@ -26,13 +26,17 @@
 				</td>
 				<td>{{ report.reason }}</td>
 				<td>{{ report.created_time }}</td>
-				<td style="width: 15%">
+				<td style="width: 180px">
 					<form method="post">
 						{{ report_action.csrf_token }}
-						{{ report_action.action }}
 						{{ report_action.torrent(value=report.torrent.id) }}
 						{{ report_action.report(value=report.id) }}
-						<button type="submit" class="btn btn-primary pull-right">Review</button>
+						<div class="input-group input-group-sm">
+							{{ report_action.action(class_="form-control") }}
+							<div class="input-group-btn">
+								<button type="submit" class="btn btn-primary">Review</button>
+							</div>
+						</div>
 					</form>
 				</td>
 			</tr>

--- a/nyaa/templates/reports.html
+++ b/nyaa/templates/reports.html
@@ -20,13 +20,24 @@
 				<td>{{ report.id }}</td>
 				<td>
 					<a href="{{ url_for('view_user', user_name=report.user.username) }}">{{ report.user.username }}</a>
+					{% if report.user.is_trusted %}
+					<span class="label label-success pull-right">Trusted</span>
+					{% endif %}
 				</td>
 				<td>
 					<a href="{{ url_for('view_torrent', torrent_id=report.torrent.id) }}">{{ report.torrent.display_name }}</a>
+					by <a href="{{ url_for('view_user', user_name=report.torrent.user.username) }}">
+					{{ report.torrent.user.username }}</a>
+					{% if g.user.is_superadmin and report.torrent.uploader_ip %}
+					({{ report.torrent.uploader_ip_string }})
+					{% endif %}
+					{% if report.torrent.user.is_trusted %}
+					<span class="label label-success pull-right">Trusted</span>
+					{% endif %}
 				</td>
 				<td>{{ report.reason }}</td>
 				<td>{{ report.created_time }}</td>
-				<td style="width: 180px">
+				<td style="min-width: 150px">
 					<form method="post">
 						{{ report_action.csrf_token }}
 						{{ report_action.torrent(value=report.torrent.id) }}

--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -189,6 +189,12 @@
 				<h4 class="modal-title">Report torrent #{{ torrent.id }}</h4>
 			</div>
 			<div class="modal-body">
+				<div class="alert alert-warning" role="alert">
+					Before submitting a report, please check that the torrent
+					actually breaks <a href="{{ url_for('site_rules') }}">the
+					rules</a>. Useless reports like "download is slow" or
+					"thanks" can get you banned from the site.
+				</div>
 				<form method="POST" action="{{ request.url }}/submit_report">
 					{{ report_form.csrf_token }}
 					{{ render_field(report_form.reason, class_='form-control', maxlength=255) }}


### PR DESCRIPTION
A bunch of small mostly styling changes, affecting reports and the report list.

* A small warning is added to the report modal to tell people that they should only report things that actually break the rules. Not sure if this will help, but it's worth a try.
* The reports list styling has been made more pleasant and usable.
* Extra information has been added to the reports list, such as whether the reporter is trusted, whether the uploader is trusted, the name of the uploader, and (for superadmins only) the uploader IP.
* Responsive tables blow ass.

New reports list look.
<img width="699" alt="reports list 1" src="https://user-images.githubusercontent.com/308818/27592310-70561c20-5b54-11e7-82d6-d46d7baa09d6.png">

And this is how it looks like if you narrow your browser window; getting rid of the `table-responsive` means that you can actually see the action column without scrolling if the reason is long.
<img width="487" alt="reports list 2" src="https://user-images.githubusercontent.com/308818/27592350-8ab3146a-5b54-11e7-92c1-1ab8b7dc4942.png">