### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch
+# Reverts Trusty build environment version, because 2017Q2 is broken for OrderedDict.
+group: deprecated-2017Q2
+
 language: python
 
 python: "3.6"


### PR DESCRIPTION
Reverts Trusty build environment version, because [2017Q2](https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch) breaks stuff.