### PR TITLE
[Restructure routes 3] Move admin routes into blueprint

### DIFF
--- a/nyaa/routes.py
+++ b/nyaa/routes.py
@@ -704,75 +704,6 @@ def submit_report(torrent_id):
     return flask.redirect(flask.url_for('view_torrent', torrent_id=torrent_id))
 
 
-@app.route('/adminlog', methods=['GET'])
-def view_adminlog():
-    if not flask.g.user or not flask.g.user.is_moderator:
-        flask.abort(403)
-
-    page = flask.request.args.get('p', flask.request.args.get('offset', 1, int), int)
-    logs = models.AdminLog.all_logs() \
-        .order_by(models.AdminLog.created_time.desc()) \
-        .paginate(page=page, per_page=20)
-
-    return flask.render_template('adminlog.html',
-                                 adminlog=logs)
-
-
-@app.route('/reports', methods=['GET', 'POST'])
-def view_reports():
-    if not flask.g.user or not flask.g.user.is_moderator:
-        flask.abort(403)
-
-    page = flask.request.args.get('p', flask.request.args.get('offset', 1, int), int)
-    reports = models.Report.not_reviewed(page)
-    report_action = forms.ReportActionForm(flask.request.form)
-
-    if flask.request.method == 'POST' and report_action.validate():
-        action = report_action.action.data
-        torrent_id = report_action.torrent.data
-        report_id = report_action.report.data
-        torrent = models.Torrent.by_id(torrent_id)
-        report = models.Report.by_id(report_id)
-        report_user = models.User.by_id(report.user_id)
-
-        if not torrent or not report or report.status != 0:
-            flask.abort(404)
-        else:
-            log = "Report #{}: {} [#{}]({}), reported by [{}]({})"
-            if action == 'delete':
-                torrent.deleted = True
-                report.status = 1
-                log = log.format(report_id, 'Deleted', torrent_id,
-                                 flask.url_for('view_torrent', torrent_id=torrent_id),
-                                 report_user.username,
-                                 flask.url_for('view_user', user_name=report_user.username))
-            elif action == 'hide':
-                log = log.format(report_id, 'Hid', torrent_id,
-                                 flask.url_for('view_torrent', torrent_id=torrent_id),
-                                 report_user.username,
-                                 flask.url_for('view_user', user_name=report_user.username))
-                torrent.hidden = True
-                report.status = 1
-            else:
-                log = log.format(report_id, 'Closed', torrent_id,
-                                 flask.url_for('view_torrent', torrent_id=torrent_id),
-                                 report_user.username,
-                                 flask.url_for('view_user', user_name=report_user.username))
-                report.status = 2
-
-            adminlog = models.AdminLog(log=log, admin_id=flask.g.user.id)
-            db.session.add(adminlog)
-
-            models.Report.remove_reviewed(torrent_id)
-            db.session.commit()
-            flask.flash('Closed report #{}'.format(report.id), 'success')
-            return flask.redirect(flask.url_for('view_reports'))
-
-    return flask.render_template('reports.html',
-                                 reports=reports,
-                                 report_action=report_action)
-
-
 def _get_cached_torrent_file(torrent):
     # Note: obviously temporary
     cached_torrent = os.path.join(app.config['BASE_DIR'],
@@ -853,6 +784,7 @@ def register_blueprints(flask_app):
     flask_app.register_blueprint(api_handler.api_blueprint, url_prefix='/api')
     # Site routes
     flask_app.register_blueprint(views.account_bp)
+    flask_app.register_blueprint(views.admin_bp)
     flask_app.register_blueprint(views.site_bp)
 
 

--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -95,8 +95,8 @@
 								<span class="caret"></span>
 							</a>
 							<ul class="dropdown-menu">
-								<li {% if request.path == url_for('view_reports') %}class="active"{% endif %}><a href="{{ url_for('view_reports') }}">Reports</a></li>
-								<li {% if request.path == url_for('view_adminlog') %}class="active"{% endif %}><a href="{{ url_for('view_adminlog') }}">Log</a></li>
+								<li {% if request.path == url_for('admin.reports') %}class="active"{% endif %}><a href="{{ url_for('admin.reports') }}">Reports</a></li>
+								<li {% if request.path == url_for('admin.log') %}class="active"{% endif %}><a href="{{ url_for('admin.log') }}">Log</a></li>
 							</ul>
 						</li>
 						{% endif %}

--- a/nyaa/views/__init__.py
+++ b/nyaa/views/__init__.py
@@ -1,7 +1,9 @@
 from nyaa.views import (
     account,
+    admin,
     site,
 )
 
 account_bp = account.bp
+admin_bp = admin.bp
 site_bp = site.bp

--- a/nyaa/views/admin.py
+++ b/nyaa/views/admin.py
@@ -1,0 +1,74 @@
+import flask
+
+from nyaa import db, forms, models
+
+bp = flask.Blueprint('admin', __name__)
+
+
+@bp.route('/adminlog', endpoint='log', methods=['GET'])
+def view_adminlog():
+    if not flask.g.user or not flask.g.user.is_moderator:
+        flask.abort(403)
+
+    page = flask.request.args.get('p', flask.request.args.get('offset', 1, int), int)
+    logs = models.AdminLog.all_logs() \
+        .order_by(models.AdminLog.created_time.desc()) \
+        .paginate(page=page, per_page=20)
+
+    return flask.render_template('adminlog.html',
+                                 adminlog=logs)
+
+
+@bp.route('/reports', endpoint='reports', methods=['GET', 'POST'])
+def view_reports():
+    if not flask.g.user or not flask.g.user.is_moderator:
+        flask.abort(403)
+
+    page = flask.request.args.get('p', flask.request.args.get('offset', 1, int), int)
+    reports = models.Report.not_reviewed(page)
+    report_action = forms.ReportActionForm(flask.request.form)
+
+    if flask.request.method == 'POST' and report_action.validate():
+        action = report_action.action.data
+        torrent_id = report_action.torrent.data
+        report_id = report_action.report.data
+        torrent = models.Torrent.by_id(torrent_id)
+        report = models.Report.by_id(report_id)
+        report_user = models.User.by_id(report.user_id)
+
+        if not torrent or not report or report.status != 0:
+            flask.abort(404)
+        else:
+            log = "Report #{}: {} [#{}]({}), reported by [{}]({})"
+            if action == 'delete':
+                torrent.deleted = True
+                report.status = 1
+                log = log.format(report_id, 'Deleted', torrent_id,
+                                 flask.url_for('view_torrent', torrent_id=torrent_id),
+                                 report_user.username,
+                                 flask.url_for('view_user', user_name=report_user.username))
+            elif action == 'hide':
+                log = log.format(report_id, 'Hid', torrent_id,
+                                 flask.url_for('view_torrent', torrent_id=torrent_id),
+                                 report_user.username,
+                                 flask.url_for('view_user', user_name=report_user.username))
+                torrent.hidden = True
+                report.status = 1
+            else:
+                log = log.format(report_id, 'Closed', torrent_id,
+                                 flask.url_for('view_torrent', torrent_id=torrent_id),
+                                 report_user.username,
+                                 flask.url_for('view_user', user_name=report_user.username))
+                report.status = 2
+
+            adminlog = models.AdminLog(log=log, admin_id=flask.g.user.id)
+            db.session.add(adminlog)
+
+            models.Report.remove_reviewed(torrent_id)
+            db.session.commit()
+            flask.flash('Closed report #{}'.format(report.id), 'success')
+            return flask.redirect(flask.url_for('admin.reports'))
+
+    return flask.render_template('reports.html',
+                                 reports=reports,
+                                 report_action=report_action)


### PR DESCRIPTION
**_Note:_ This PR is against the 'blueprints' branch.**
[3rd pull request out of 8 in total]

This PR moves the following routes into the `admin` blueprint (`nyaa/views/admin.py`):
* /reports
* /adminlog

`url_for()`-s in templates and routes were updated.

These are pretty straight-forward because they are relatively new.

***

You can also use git blame to see what code was actually changed by me (and what was plainly copied)
```console
git blame -C HEAD -- nyaa/views/admin.py
```