### PR TITLE
[Restructure routes 4] Move user routes into blueprint

### DIFF
--- a/nyaa/routes.py
+++ b/nyaa/routes.py
@@ -11,7 +11,6 @@ from flask_paginate import Pagination
 from werkzeug import url_encode
 from werkzeug.datastructures import CombinedMultiDict
 
-from itsdangerous import BadSignature, URLSafeSerializer
 from sqlalchemy.orm import joinedload
 
 from nyaa import api_handler, app, backend, db, forms, models, torrents, views
@@ -286,27 +285,6 @@ def render_rss(label, query, use_elastic, magnet_links=False):
     return response
 
 
-@app.route('/user/activate/<payload>')
-def activate_user(payload):
-    s = get_serializer()
-    try:
-        user_id = s.loads(payload)
-    except BadSignature:
-        flask.abort(404)
-
-    user = models.User.by_id(user_id)
-
-    if not user:
-        flask.abort(404)
-
-    user.status = models.UserStatusType.ACTIVE
-
-    db.session.add(user)
-    db.session.commit()
-
-    return flask.redirect('/login')
-
-
 @cached_function
 def _create_upload_category_choices():
     ''' Turns categories in the database into a list of (id, name)s '''
@@ -561,18 +539,6 @@ def _get_cached_torrent_file(torrent):
             out_file.write(torrents.create_bencoded_torrent(torrent))
 
     return open(cached_torrent, 'rb')
-
-
-def get_serializer(secret_key=None):
-    if secret_key is None:
-        secret_key = app.secret_key
-    return URLSafeSerializer(secret_key)
-
-
-def get_activation_link(user):
-    s = get_serializer()
-    payload = s.dumps(user.id)
-    return flask.url_for('activate_user', payload=payload, _external=True)
 
 
 @app.template_filter()

--- a/nyaa/routes.py
+++ b/nyaa/routes.py
@@ -14,15 +14,12 @@ from werkzeug.datastructures import CombinedMultiDict
 from itsdangerous import BadSignature, URLSafeSerializer
 from sqlalchemy.orm import joinedload
 
-from nyaa import api_handler, app, backend, db, forms, models, torrents, utils, views
-from nyaa.search import search_db, search_elastic
+from nyaa import api_handler, app, backend, db, forms, models, torrents, views
+from nyaa.search import (DEFAULT_MAX_SEARCH_RESULT, DEFAULT_PER_PAGE, SERACH_PAGINATE_DISPLAY_MSG,
+                         _generate_query_string, search_db, search_elastic)
+from nyaa.utils import cached_function, chain_get
 
 DEBUG_API = False
-DEFAULT_MAX_SEARCH_RESULT = 1000
-DEFAULT_PER_PAGE = 75
-SERACH_PAGINATE_DISPLAY_MSG = ('Displaying results {start}-{end} out of {total} results.<br>\n'
-                               'Please refine your search results if you can\'t find '
-                               'what you were looking for.')
 
 
 # For static_cachebuster
@@ -100,19 +97,6 @@ def before_request():
             return 'You are banned.', 403
 
 
-def _generate_query_string(term, category, filter, user):
-    params = {}
-    if term:
-        params['q'] = str(term)
-    if category:
-        params['c'] = str(category)
-    if filter:
-        params['f'] = str(filter)
-    if user:
-        params['u'] = str(user)
-    return params
-
-
 @app.template_filter('utc_time')
 def get_utc_timestamp(datetime_str):
     ''' Returns a UTC POSIX timestamp, as seconds '''
@@ -125,7 +109,7 @@ def get_display_time(datetime_str):
     return datetime.strptime(datetime_str, '%Y-%m-%dT%H:%M:%S').strftime('%Y-%m-%d %H:%M')
 
 
-@utils.cached_function
+@cached_function
 def get_category_id_map():
     ''' Reads database for categories and turns them into a dict with
         ids as keys and name list as the value, ala
@@ -139,18 +123,6 @@ def get_category_id_map():
 
 
 # Routes start here #
-
-
-def chain_get(source, *args):
-    ''' Tries to return values from source by the given keys.
-        Returns None if none match.
-        Note: can return a None from the source. '''
-    sentinel = object()
-    for key in args:
-        value = source.get(key, sentinel)
-        if value is not sentinel:
-            return value
-    return None
 
 
 @app.route('/rss', defaults={'rss': True})
@@ -290,130 +262,6 @@ def home(rss):
                                          special_results=special_results)
 
 
-@app.route('/user/<user_name>', methods=['GET', 'POST'])
-def view_user(user_name):
-    user = models.User.by_username(user_name)
-
-    if not user:
-        flask.abort(404)
-
-    admin_form = None
-    if flask.g.user and flask.g.user.is_moderator and flask.g.user.level > user.level:
-        admin_form = forms.UserForm()
-        default, admin_form.user_class.choices = _create_user_class_choices(user)
-        if flask.request.method == 'GET':
-            admin_form.user_class.data = default
-
-    url = flask.url_for('view_user', user_name=user.username)
-    if flask.request.method == 'POST' and admin_form and admin_form.validate():
-        selection = admin_form.user_class.data
-        log = None
-        if selection == 'regular':
-            user.level = models.UserLevelType.REGULAR
-            log = "[{}]({}) changed to regular user".format(user_name, url)
-        elif selection == 'trusted':
-            user.level = models.UserLevelType.TRUSTED
-            log = "[{}]({}) changed to trusted user".format(user_name, url)
-        elif selection == 'moderator':
-            user.level = models.UserLevelType.MODERATOR
-            log = "[{}]({}) changed to moderator user".format(user_name, url)
-        elif selection == 'disabled':
-            user.status = models.UserStatusType.BANNED
-            log = "[{}]({}) changed to banned user".format(user_name, url)
-
-        adminlog = models.AdminLog(log=log, admin_id=flask.g.user.id)
-        db.session.add(user)
-        db.session.add(adminlog)
-        db.session.commit()
-
-        return flask.redirect(url)
-
-    user_level = ['Regular', 'Trusted', 'Moderator', 'Administrator'][user.level]
-
-    req_args = flask.request.args
-
-    search_term = chain_get(req_args, 'q', 'term')
-
-    sort_key = req_args.get('s')
-    sort_order = req_args.get('o')
-
-    category = chain_get(req_args, 'c', 'cats')
-    quality_filter = chain_get(req_args, 'f', 'filter')
-
-    page_number = chain_get(req_args, 'p', 'page', 'offset')
-    try:
-        page_number = max(1, int(page_number))
-    except (ValueError, TypeError):
-        page_number = 1
-
-    results_per_page = app.config.get('RESULTS_PER_PAGE', DEFAULT_PER_PAGE)
-
-    query_args = {
-        'term': search_term or '',
-        'user': user.id,
-        'sort': sort_key or 'id',
-        'order': sort_order or 'desc',
-        'category': category or '0_0',
-        'quality_filter': quality_filter or '0',
-        'page': page_number,
-        'rss': False,
-        'per_page': results_per_page
-    }
-
-    if flask.g.user:
-        query_args['logged_in_user'] = flask.g.user
-        if flask.g.user.is_moderator:  # God mode
-            query_args['admin'] = True
-
-    # Use elastic search for term searching
-    rss_query_string = _generate_query_string(search_term, category, quality_filter, user_name)
-    use_elastic = app.config.get('USE_ELASTIC_SEARCH')
-    if use_elastic and search_term:
-        query_args['term'] = search_term
-
-        max_search_results = app.config.get('ES_MAX_SEARCH_RESULT', DEFAULT_MAX_SEARCH_RESULT)
-
-        # Only allow up to (max_search_results / page) pages
-        max_page = min(query_args['page'], int(math.ceil(max_search_results / results_per_page)))
-
-        query_args['page'] = max_page
-        query_args['max_search_results'] = max_search_results
-
-        query_results = search_elastic(**query_args)
-
-        max_results = min(max_search_results, query_results['hits']['total'])
-        # change p= argument to whatever you change page_parameter to or pagination breaks
-        pagination = Pagination(p=query_args['page'], per_page=results_per_page,
-                                total=max_results, bs_version=3, page_parameter='p',
-                                display_msg=SERACH_PAGINATE_DISPLAY_MSG)
-        return flask.render_template('user.html',
-                                     use_elastic=True,
-                                     pagination=pagination,
-                                     torrent_query=query_results,
-                                     search=query_args,
-                                     user=user,
-                                     user_page=True,
-                                     rss_filter=rss_query_string,
-                                     level=user_level,
-                                     admin_form=admin_form)
-    # Similar logic as home page
-    else:
-        if use_elastic:
-            query_args['term'] = ''
-        else:
-            query_args['term'] = search_term or ''
-        query = search_db(**query_args)
-        return flask.render_template('user.html',
-                                     use_elastic=False,
-                                     torrent_query=query,
-                                     search=query_args,
-                                     user=user,
-                                     user_page=True,
-                                     rss_filter=rss_query_string,
-                                     level=user_level,
-                                     admin_form=admin_form)
-
-
 @app.template_filter('rfc822')
 def _jinja2_filter_rfc822(date, fmt=None):
     return formatdate(date.timestamp())
@@ -459,7 +307,7 @@ def activate_user(payload):
     return flask.redirect('/login')
 
 
-@utils.cached_function
+@cached_function
 def _create_upload_category_choices():
     ''' Turns categories in the database into a list of (id, name)s '''
     choices = [('', '[Select a category]')]
@@ -727,25 +575,6 @@ def get_activation_link(user):
     return flask.url_for('activate_user', payload=payload, _external=True)
 
 
-def _create_user_class_choices(user):
-    choices = [('regular', 'Regular')]
-    default = 'regular'
-    if flask.g.user:
-        if flask.g.user.is_moderator:
-            choices.append(('trusted', 'Trusted'))
-        if flask.g.user.is_superadmin:
-            choices.append(('moderator', 'Moderator'))
-            choices.append(('disabled', 'Disabled'))
-
-        if user:
-            if user.is_moderator:
-                default = 'moderator'
-            elif user.is_trusted:
-                default = 'trusted'
-
-    return default, choices
-
-
 @app.template_filter()
 def timesince(dt, default='just now'):
     """
@@ -786,6 +615,7 @@ def register_blueprints(flask_app):
     flask_app.register_blueprint(views.account_bp)
     flask_app.register_blueprint(views.admin_bp)
     flask_app.register_blueprint(views.site_bp)
+    flask_app.register_blueprint(views.users_bp)
 
 
 # When done, this can be moved to nyaa/__init__.py instead of importing this file

--- a/nyaa/search.py
+++ b/nyaa/search.py
@@ -13,6 +13,25 @@ from sqlalchemy_fulltext import FullTextSearch
 from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search, Q
 
+DEFAULT_MAX_SEARCH_RESULT = 1000
+DEFAULT_PER_PAGE = 75
+SERACH_PAGINATE_DISPLAY_MSG = ('Displaying results {start}-{end} out of {total} results.<br>\n'
+                               'Please refine your search results if you can\'t find '
+                               'what you were looking for.')
+
+
+def _generate_query_string(term, category, filter, user):
+    params = {}
+    if term:
+        params['q'] = str(term)
+    if category:
+        params['c'] = str(category)
+    if filter:
+        params['f'] = str(filter)
+    if user:
+        params['u'] = str(user)
+    return params
+
 
 def search_elastic(term='', user=None, sort='id', order='desc',
                    category='0_0', quality_filter='0', page=1,

--- a/nyaa/templates/adminlog.html
+++ b/nyaa/templates/adminlog.html
@@ -17,7 +17,7 @@
 			<tr>
 				<td>{{ log.id }}</td>
 				<td>
-					<a href="{{ url_for('view_user', user_name=log.admin.username) }}">{{ log.admin.username }}</a>
+					<a href="{{ url_for('users.view_user', user_name=log.admin.username) }}">{{ log.admin.username }}</a>
 				</td>
 				<td><div markdown-text>{{ log.log }}</div></td>
 				<td>{{ log.created_time }}</td>

--- a/nyaa/templates/edit.html
+++ b/nyaa/templates/edit.html
@@ -8,7 +8,7 @@
 <h1>
 	Edit Torrent <a href="{{ torrent_url }}">#{{torrent.id}}</a>
 	{% if (torrent.user != None) and (torrent.user != g.user) %}
-	(by <a href="{{ url_for('view_user', user_name=torrent.user.username) }}">{{ torrent.user.username }}</a>)
+	(by <a href="{{ url_for('users.view_user', user_name=torrent.user.username) }}">{{ torrent.user.username }}</a>)
 	{% endif %}
 </h1>
 

--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -122,7 +122,7 @@
 	
 								</li>
 								<li>
-									<a href="{{ url_for('view_user', user_name=g.user.username) }}">
+									<a href="{{ url_for('users.view_user', user_name=g.user.username) }}">
 										<i class="fa fa-user fa-fw"></i>
 										Torrents
 									</a>
@@ -214,7 +214,7 @@
 					<div class="search-container visible-xs visible-sm">
 					{# The mobile menu #}
 						{% if user_page %}
-						<form class="navbar-form navbar-right form" action="{{ url_for('view_user', user_name=user.username) }}" method="get">
+						<form class="navbar-form navbar-right form" action="{{ url_for('users.view_user', user_name=user.username) }}" method="get">
 						{% else %}
 						<form class="navbar-form navbar-right form" action="{{ url_for('home') }}" method="get">
 						{% endif %}
@@ -250,7 +250,7 @@
 					</div><!--/.search-container -->
 
 					{% if user_page %}
-					<form class="navbar-form navbar-right form" action="{{ url_for('view_user', user_name=user.username) }}" method="get">
+					<form class="navbar-form navbar-right form" action="{{ url_for('users.view_user', user_name=user.username) }}" method="get">
 					{% else %}
 					<form class="navbar-form navbar-right form" action="{{ url_for('home') }}" method="get">
 					{% endif %}

--- a/nyaa/templates/reports.html
+++ b/nyaa/templates/reports.html
@@ -19,14 +19,14 @@
 			<tr class="reports-row">
 				<td>{{ report.id }}</td>
 				<td>
-					<a href="{{ url_for('view_user', user_name=report.user.username) }}">{{ report.user.username }}</a>
+					<a href="{{ url_for('users.view_user', user_name=report.user.username) }}">{{ report.user.username }}</a>
 					{% if report.user.is_trusted %}
 					<span class="label label-success pull-right">Trusted</span>
 					{% endif %}
 				</td>
 				<td>
 					<a href="{{ url_for('view_torrent', torrent_id=report.torrent.id) }}">{{ report.torrent.display_name }}</a>
-					by <a href="{{ url_for('view_user', user_name=report.torrent.user.username) }}">
+					by <a href="{{ url_for('users.view_user', user_name=report.torrent.user.username) }}">
 					{{ report.torrent.user.username }}</a>
 					{% if g.user.is_superadmin and report.torrent.uploader_ip %}
 					({{ report.torrent.uploader_ip_string }})

--- a/nyaa/templates/search_results.html
+++ b/nyaa/templates/search_results.html
@@ -12,7 +12,7 @@
 {% if special_results is defined and not search.user %}
 {% if special_results.first_word_user %}
 <div class="alert alert-info">
-	<a href="{{ url_for('view_user', user_name=special_results.first_word_user.username) }}{{ modify_query(q=special_results.query_sans_user)[1:] }}">Click here to see only results uploaded by {{ special_results.first_word_user.username }}</a>
+	<a href="{{ url_for('users.view_user', user_name=special_results.first_word_user.username) }}{{ modify_query(q=special_results.query_sans_user)[1:] }}">Click here to see only results uploaded by {{ special_results.first_word_user.username }}</a>
 </div>
 {% endif %}
 {% endif %}

--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -29,7 +29,7 @@
 		<div class="row">
 			<div class="col-md-1">Submitter:</div>
 			<div class="col-md-5">
-				{% set user_url = torrent.user and url_for('view_user', user_name=torrent.user.username) %}
+				{% set user_url = torrent.user and url_for('users.view_user', user_name=torrent.user.username) %}
 				{%- if not torrent.anonymous and torrent.user -%}
 				<a class="text-{{ torrent.user.userlevel_color }}" href="{{ user_url }}">{{ torrent.user.username }}</a>
 				{%- else -%}
@@ -145,7 +145,7 @@
 		<div class="panel-body">
 			<div class="col-md-2">
 				<p>
-					<a class="text-{{ comment.user.userlevel_color }}" href="{{ url_for('view_user', user_name=comment.user.username) }}">{{ comment.user.username }}</a>
+					<a class="text-{{ comment.user.userlevel_color }}" href="{{ url_for('users.view_user', user_name=comment.user.username) }}">{{ comment.user.username }}</a>
 					{% if comment.user.id == torrent.uploader_id and not torrent.anonymous %}
 					(uploader)
 					{% endif %}

--- a/nyaa/utils.py
+++ b/nyaa/utils.py
@@ -59,3 +59,15 @@ def flatten_dict(d, result=None):
         else:
             result[key] = value
     return result
+
+
+def chain_get(source, *args):
+    ''' Tries to return values from source by the given keys.
+        Returns None if none match.
+        Note: can return a None from the source. '''
+    sentinel = object()
+    for key in args:
+        value = source.get(key, sentinel)
+        if value is not sentinel:
+            return value
+    return None

--- a/nyaa/views/__init__.py
+++ b/nyaa/views/__init__.py
@@ -2,8 +2,10 @@ from nyaa.views import (
     account,
     admin,
     site,
+    users,
 )
 
 account_bp = account.bp
 admin_bp = admin.bp
 site_bp = site.bp
+users_bp = users.bp

--- a/nyaa/views/account.py
+++ b/nyaa/views/account.py
@@ -6,8 +6,8 @@ from ipaddress import ip_address
 
 import flask
 
-# Importing nyaa.routes for get_activation_link
-from nyaa import app, db, forms, models, routes
+from nyaa import app, db, forms, models
+from nyaa.views.users import get_activation_link
 
 bp = flask.Blueprint('account', __name__)
 
@@ -72,7 +72,7 @@ def register():
         db.session.commit()
 
         if app.config['USE_EMAIL_VERIFICATION']:  # force verification, enable email
-            activ_link = routes.get_activation_link(user)
+            activ_link = get_activation_link(user)
             send_verification_email(user.email, activ_link)
             return flask.render_template('waiting.html')
         else:  # disable verification, set user as active and auto log in

--- a/nyaa/views/admin.py
+++ b/nyaa/views/admin.py
@@ -46,19 +46,19 @@ def view_reports():
                 log = log.format(report_id, 'Deleted', torrent_id,
                                  flask.url_for('view_torrent', torrent_id=torrent_id),
                                  report_user.username,
-                                 flask.url_for('view_user', user_name=report_user.username))
+                                 flask.url_for('users.view_user', user_name=report_user.username))
             elif action == 'hide':
                 log = log.format(report_id, 'Hid', torrent_id,
                                  flask.url_for('view_torrent', torrent_id=torrent_id),
                                  report_user.username,
-                                 flask.url_for('view_user', user_name=report_user.username))
+                                 flask.url_for('users.view_user', user_name=report_user.username))
                 torrent.hidden = True
                 report.status = 1
             else:
                 log = log.format(report_id, 'Closed', torrent_id,
                                  flask.url_for('view_torrent', torrent_id=torrent_id),
                                  report_user.username,
-                                 flask.url_for('view_user', user_name=report_user.username))
+                                 flask.url_for('users.view_user', user_name=report_user.username))
                 report.status = 2
 
             adminlog = models.AdminLog(log=log, admin_id=flask.g.user.id)

--- a/nyaa/views/users.py
+++ b/nyaa/views/users.py
@@ -1,0 +1,154 @@
+import math
+
+import flask
+from flask_paginate import Pagination
+
+from nyaa import app, db, forms, models
+from nyaa.search import (DEFAULT_MAX_SEARCH_RESULT, DEFAULT_PER_PAGE, SERACH_PAGINATE_DISPLAY_MSG,
+                         _generate_query_string, search_db, search_elastic)
+from nyaa.utils import chain_get
+
+bp = flask.Blueprint('users', __name__)
+
+
+@bp.route('/user/<user_name>', methods=['GET', 'POST'])
+def view_user(user_name):
+    user = models.User.by_username(user_name)
+
+    if not user:
+        flask.abort(404)
+
+    admin_form = None
+    if flask.g.user and flask.g.user.is_moderator and flask.g.user.level > user.level:
+        admin_form = forms.UserForm()
+        default, admin_form.user_class.choices = _create_user_class_choices(user)
+        if flask.request.method == 'GET':
+            admin_form.user_class.data = default
+
+    url = flask.url_for('users.view_user', user_name=user.username)
+    if flask.request.method == 'POST' and admin_form and admin_form.validate():
+        selection = admin_form.user_class.data
+        log = None
+        if selection == 'regular':
+            user.level = models.UserLevelType.REGULAR
+            log = "[{}]({}) changed to regular user".format(user_name, url)
+        elif selection == 'trusted':
+            user.level = models.UserLevelType.TRUSTED
+            log = "[{}]({}) changed to trusted user".format(user_name, url)
+        elif selection == 'moderator':
+            user.level = models.UserLevelType.MODERATOR
+            log = "[{}]({}) changed to moderator user".format(user_name, url)
+        elif selection == 'disabled':
+            user.status = models.UserStatusType.BANNED
+            log = "[{}]({}) changed to banned user".format(user_name, url)
+
+        adminlog = models.AdminLog(log=log, admin_id=flask.g.user.id)
+        db.session.add(user)
+        db.session.add(adminlog)
+        db.session.commit()
+
+        return flask.redirect(url)
+
+    user_level = ['Regular', 'Trusted', 'Moderator', 'Administrator'][user.level]
+
+    req_args = flask.request.args
+
+    search_term = chain_get(req_args, 'q', 'term')
+
+    sort_key = req_args.get('s')
+    sort_order = req_args.get('o')
+
+    category = chain_get(req_args, 'c', 'cats')
+    quality_filter = chain_get(req_args, 'f', 'filter')
+
+    page_number = chain_get(req_args, 'p', 'page', 'offset')
+    try:
+        page_number = max(1, int(page_number))
+    except (ValueError, TypeError):
+        page_number = 1
+
+    results_per_page = app.config.get('RESULTS_PER_PAGE', DEFAULT_PER_PAGE)
+
+    query_args = {
+        'term': search_term or '',
+        'user': user.id,
+        'sort': sort_key or 'id',
+        'order': sort_order or 'desc',
+        'category': category or '0_0',
+        'quality_filter': quality_filter or '0',
+        'page': page_number,
+        'rss': False,
+        'per_page': results_per_page
+    }
+
+    if flask.g.user:
+        query_args['logged_in_user'] = flask.g.user
+        if flask.g.user.is_moderator:  # God mode
+            query_args['admin'] = True
+
+    # Use elastic search for term searching
+    rss_query_string = _generate_query_string(search_term, category, quality_filter, user_name)
+    use_elastic = app.config.get('USE_ELASTIC_SEARCH')
+    if use_elastic and search_term:
+        query_args['term'] = search_term
+
+        max_search_results = app.config.get('ES_MAX_SEARCH_RESULT', DEFAULT_MAX_SEARCH_RESULT)
+
+        # Only allow up to (max_search_results / page) pages
+        max_page = min(query_args['page'], int(math.ceil(max_search_results / results_per_page)))
+
+        query_args['page'] = max_page
+        query_args['max_search_results'] = max_search_results
+
+        query_results = search_elastic(**query_args)
+
+        max_results = min(max_search_results, query_results['hits']['total'])
+        # change p= argument to whatever you change page_parameter to or pagination breaks
+        pagination = Pagination(p=query_args['page'], per_page=results_per_page,
+                                total=max_results, bs_version=3, page_parameter='p',
+                                display_msg=SERACH_PAGINATE_DISPLAY_MSG)
+        return flask.render_template('user.html',
+                                     use_elastic=True,
+                                     pagination=pagination,
+                                     torrent_query=query_results,
+                                     search=query_args,
+                                     user=user,
+                                     user_page=True,
+                                     rss_filter=rss_query_string,
+                                     level=user_level,
+                                     admin_form=admin_form)
+    # Similar logic as home page
+    else:
+        if use_elastic:
+            query_args['term'] = ''
+        else:
+            query_args['term'] = search_term or ''
+        query = search_db(**query_args)
+        return flask.render_template('user.html',
+                                     use_elastic=False,
+                                     torrent_query=query,
+                                     search=query_args,
+                                     user=user,
+                                     user_page=True,
+                                     rss_filter=rss_query_string,
+                                     level=user_level,
+                                     admin_form=admin_form)
+
+
+def _create_user_class_choices(user):
+    choices = [('regular', 'Regular')]
+    default = 'regular'
+    if flask.g.user:
+        if flask.g.user.is_moderator:
+            choices.append(('trusted', 'Trusted'))
+        if flask.g.user.is_superadmin:
+            choices.append(('moderator', 'Moderator'))
+            choices.append(('disabled', 'Disabled'))
+
+        if user:
+            if user.is_moderator:
+                default = 'moderator'
+            elif user.is_trusted:
+                default = 'trusted'
+
+    return default, choices


### PR DESCRIPTION
**_Note:_ This PR is against the 'blueprints' branch.**
[4th pull request out of 8 in total]

This PR moves the following routes into the `users` blueprint (`nyaa/views/users.py`):

* /user/`<user_name>`
* /user/activate/`<payload>`

`url_for()`-s in templates and routes were updated.

This moves supporting functions and variables into other files:
* Into `nyaa.utils`:
  - `cached_function()`
  - `chain_get()`
* Into `nyaa.search`:
  - `DEFAULT_MAX_SEARCH_RESULT`
  - `DEFAULT_PER_PAGE`
  - `SERACH_PAGINATE_DISPLAY_MSG`
  - `_generate_query_string`
* Into the blueprint `nyaa.views.users`:
  - `get_serializer()`
  - `get_activation_link()`

**Notes:**
Some changes made to the master branch (https://github.com/nyaadevs/nyaa/commit/b51045503deab41e5db27caec725c9cd4b9c2f98) are not in this branch (to keep things simple).
When we open the PR from `blueprints` to `master`, it will cause conflicts, and I'll resolve them :+1: 

***

You can also use git blame to see what code was actually changed by me (and what was plainly copied)
```console
git blame -C HEAD -- nyaa/views/users.py
```

### Testing progress:
- [x] `get_serializer()`
- [x] `get_activation_link()`
- [x] GET `/user/<user_name>`
- [x] POST `/user/<user_name>` (change user level)
- [x] `/user/activate/<payload>`
- [x] `/adminlog`
- [x] GET `/reports`
- [x] POST `/reports` (perform action - close)
- [x] GET `/view/<torrent_id>/edit`
- [x] POST `/view/<torrent_id>/edit` (do edit)
- [x] GET `/view/<torrent_id>` (with comments)
- [x] POST `/view/<torrent_id>` (post comment)