### PR TITLE
[Restructure routes 6] Move home, RSS and request handlers into blueprint

### DIFF
--- a/nyaa/api_handler.py
+++ b/nyaa/api_handler.py
@@ -24,7 +24,7 @@ api_blueprint = flask.Blueprint('api', __name__)
 def basic_auth_user(f):
     ''' A decorator that will try to validate the user into g.user from basic auth.
         Note: this does not set user to None on failure, so users can also authorize
-        themselves with the cookie (handled in routes.before_request). '''
+        themselves with the cookie (handled in views.main.before_request). '''
     @functools.wraps(f)
     def decorator(*args, **kwargs):
         auth = flask.request.authorization

--- a/nyaa/routes.py
+++ b/nyaa/routes.py
@@ -1,20 +1,15 @@
 import json
-import math
 import os.path
-import re
 from datetime import datetime, timedelta
 from urllib.parse import quote
 
 import flask
-from flask_paginate import Pagination
 from werkzeug.datastructures import CombinedMultiDict
 
 from sqlalchemy.orm import joinedload
 
 from nyaa import api_handler, app, backend, db, forms, models, template_utils, torrents, views
-from nyaa.search import (DEFAULT_MAX_SEARCH_RESULT, DEFAULT_PER_PAGE, SERACH_PAGINATE_DISPLAY_MSG,
-                         _generate_query_string, search_db, search_elastic)
-from nyaa.utils import cached_function, chain_get
+from nyaa.utils import cached_function
 
 DEBUG_API = False
 
@@ -63,158 +58,6 @@ def get_category_id_map():
 
 
 # Routes start here #
-
-
-@app.route('/rss', defaults={'rss': True})
-@app.route('/', defaults={'rss': False})
-def home(rss):
-    render_as_rss = rss
-    req_args = flask.request.args
-    if req_args.get('page') == 'rss':
-        render_as_rss = True
-
-    search_term = chain_get(req_args, 'q', 'term')
-
-    sort_key = req_args.get('s')
-    sort_order = req_args.get('o')
-
-    category = chain_get(req_args, 'c', 'cats')
-    quality_filter = chain_get(req_args, 'f', 'filter')
-
-    user_name = chain_get(req_args, 'u', 'user')
-    page_number = chain_get(req_args, 'p', 'page', 'offset')
-    try:
-        page_number = max(1, int(page_number))
-    except (ValueError, TypeError):
-        page_number = 1
-
-    # Check simply if the key exists
-    use_magnet_links = 'magnets' in req_args or 'm' in req_args
-
-    results_per_page = app.config.get('RESULTS_PER_PAGE', DEFAULT_PER_PAGE)
-
-    user_id = None
-    if user_name:
-        user = models.User.by_username(user_name)
-        if not user:
-            flask.abort(404)
-        user_id = user.id
-
-    special_results = {
-        'first_word_user': None,
-        'query_sans_user': None,
-        'infohash_torrent': None
-    }
-    # Add advanced features to searches (but not RSS or user searches)
-    if search_term and not render_as_rss and not user_id:
-        # Check if the first word of the search is an existing user
-        user_word_match = re.match(r'^([a-zA-Z0-9_-]+) *(.*|$)', search_term)
-        if user_word_match:
-            special_results['first_word_user'] = models.User.by_username(user_word_match.group(1))
-            special_results['query_sans_user'] = user_word_match.group(2)
-
-        # Check if search is a 40-char torrent hash
-        infohash_match = re.match(r'(?i)^([a-f0-9]{40})$', search_term)
-        if infohash_match:
-            # Check for info hash in database
-            matched_torrent = models.Torrent.by_info_hash_hex(infohash_match.group(1))
-            special_results['infohash_torrent'] = matched_torrent
-
-    query_args = {
-        'user': user_id,
-        'sort': sort_key or 'id',
-        'order': sort_order or 'desc',
-        'category': category or '0_0',
-        'quality_filter': quality_filter or '0',
-        'page': page_number,
-        'rss': render_as_rss,
-        'per_page': results_per_page
-    }
-
-    if flask.g.user:
-        query_args['logged_in_user'] = flask.g.user
-        if flask.g.user.is_moderator:  # God mode
-            query_args['admin'] = True
-
-    infohash_torrent = special_results.get('infohash_torrent')
-    if infohash_torrent:
-        # infohash_torrent is only set if this is not RSS or userpage search
-        flask.flash(flask.Markup('You were redirected here because '
-                                 'the given hash matched this torrent.'), 'info')
-        # Redirect user from search to the torrent if we found one with the specific info_hash
-        return flask.redirect(flask.url_for('view_torrent', torrent_id=infohash_torrent.id))
-
-    # If searching, we get results from elastic search
-    use_elastic = app.config.get('USE_ELASTIC_SEARCH')
-    if use_elastic and search_term:
-        query_args['term'] = search_term
-
-        max_search_results = app.config.get('ES_MAX_SEARCH_RESULT', DEFAULT_MAX_SEARCH_RESULT)
-
-        # Only allow up to (max_search_results / page) pages
-        max_page = min(query_args['page'], int(math.ceil(max_search_results / results_per_page)))
-
-        query_args['page'] = max_page
-        query_args['max_search_results'] = max_search_results
-
-        query_results = search_elastic(**query_args)
-
-        if render_as_rss:
-            return render_rss(
-                '"{}"'.format(search_term), query_results,
-                use_elastic=True, magnet_links=use_magnet_links)
-        else:
-            rss_query_string = _generate_query_string(
-                search_term, category, quality_filter, user_name)
-            max_results = min(max_search_results, query_results['hits']['total'])
-            # change p= argument to whatever you change page_parameter to or pagination breaks
-            pagination = Pagination(p=query_args['page'], per_page=results_per_page,
-                                    total=max_results, bs_version=3, page_parameter='p',
-                                    display_msg=SERACH_PAGINATE_DISPLAY_MSG)
-            return flask.render_template('home.html',
-                                         use_elastic=True,
-                                         pagination=pagination,
-                                         torrent_query=query_results,
-                                         search=query_args,
-                                         rss_filter=rss_query_string,
-                                         special_results=special_results)
-    else:
-        # If ES is enabled, default to db search for browsing
-        if use_elastic:
-            query_args['term'] = ''
-        else:  # Otherwise, use db search for everything
-            query_args['term'] = search_term or ''
-
-        query = search_db(**query_args)
-        if render_as_rss:
-            return render_rss('Home', query, use_elastic=False, magnet_links=use_magnet_links)
-        else:
-            rss_query_string = _generate_query_string(
-                search_term, category, quality_filter, user_name)
-            # Use elastic is always false here because we only hit this section
-            # if we're browsing without a search term (which means we default to DB)
-            # or if ES is disabled
-            return flask.render_template('home.html',
-                                         use_elastic=False,
-                                         torrent_query=query,
-                                         search=query_args,
-                                         rss_filter=rss_query_string,
-                                         special_results=special_results)
-
-
-def render_rss(label, query, use_elastic, magnet_links=False):
-    rss_xml = flask.render_template('rss.xml',
-                                    use_elastic=use_elastic,
-                                    magnet_links=magnet_links,
-                                    term=label,
-                                    site_url=flask.request.url_root,
-                                    torrent_query=query)
-    response = flask.make_response(rss_xml)
-    response.headers['Content-Type'] = 'application/xml'
-    # Cache for an hour
-    response.headers['Cache-Control'] = 'max-age={}'.format(1 * 5 * 60)
-    return response
-
 
 @cached_function
 def _create_upload_category_choices():
@@ -484,6 +327,7 @@ def register_blueprints(flask_app):
     # Site routes
     flask_app.register_blueprint(views.account_bp)
     flask_app.register_blueprint(views.admin_bp)
+    flask_app.register_blueprint(views.main_bp)
     flask_app.register_blueprint(views.site_bp)
     flask_app.register_blueprint(views.users_bp)
 

--- a/nyaa/routes.py
+++ b/nyaa/routes.py
@@ -1,6 +1,5 @@
 import json
 import os.path
-from datetime import datetime, timedelta
 from urllib.parse import quote
 
 import flask
@@ -23,25 +22,6 @@ def category_name(cat_id):
 @app.errorhandler(404)
 def not_found(error):
     return flask.render_template('404.html'), 404
-
-
-@app.before_request
-def before_request():
-    flask.g.user = None
-    if 'user_id' in flask.session:
-        user = models.User.by_id(flask.session['user_id'])
-        if not user:
-            return views.account.logout()
-
-        flask.g.user = user
-
-        if 'timeout' not in flask.session or flask.session['timeout'] < datetime.now():
-            flask.session['timeout'] = datetime.now() + timedelta(days=7)
-            flask.session.permanent = True
-            flask.session.modified = True
-
-        if flask.g.user.status == models.UserStatusType.BANNED:
-            return 'You are banned.', 403
 
 
 @cached_function

--- a/nyaa/routes.py
+++ b/nyaa/routes.py
@@ -19,11 +19,6 @@ def category_name(cat_id):
     return ' - '.join(get_category_id_map().get(cat_id, ['???']))
 
 
-@app.errorhandler(404)
-def not_found(error):
-    return flask.render_template('404.html'), 404
-
-
 @cached_function
 def get_category_id_map():
     ''' Reads database for categories and turns them into a dict with

--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -9,7 +9,7 @@
 		<link rel="shortcut icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
 		<link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
 		<link rel="mask-icon" href="{{ url_for('static', filename='pinned-tab.svg') }}" color="#3582F7">
-		<link rel="alternate" type="application/rss+xml" href="{% if rss_filter %}{{ url_for('home', page='rss', _external=True, **rss_filter) }}{% else %}{{ url_for('home', page='rss', _external=True) }}{% endif %}" />
+		<link rel="alternate" type="application/rss+xml" href="{% if rss_filter %}{{ url_for('main.home', page='rss', _external=True, **rss_filter) }}{% else %}{{ url_for('main.home', page='rss', _external=True) }}{% endif %}" />
 
 		<meta property="og:site_name" content="{{ config.SITE_NAME }}">
 		<meta property="og:title" content="{{ self.title() }}">
@@ -65,7 +65,7 @@
 					<span class="icon-bar"></span>
 					<span class="icon-bar"></span>
 					</button>
-					<a class="navbar-brand" href="{{ url_for('home') }}">{{ config.SITE_NAME }}</a>
+					<a class="navbar-brand" href="{{ url_for('main.home') }}">{{ config.SITE_NAME }}</a>
 				</div><!--/.navbar-header -->
 				{% set search_username = (user.username + ("'" if user.username[-1] == 's' else "'s")) if user_page else None %}
 				{% set search_placeholder = 'Search {} torrents...'.format(search_username) if user_page else 'Search...' %}
@@ -82,7 +82,7 @@
 								<li {% if request.path == url_for('site.help') %}class="active"{% endif %}><a href="{{ url_for('site.help') }}">Help</a></li>
 							</ul>
 						</li>
-						<li><a href="{% if rss_filter %}{{ url_for('home', page='rss', **rss_filter) }}{% else %}{{ url_for('home', page='rss') }}{% endif %}">RSS</a></li>
+						<li><a href="{% if rss_filter %}{{ url_for('main.home', page='rss', **rss_filter) }}{% else %}{{ url_for('main.home', page='rss') }}{% endif %}">RSS</a></li>
 						{% if config.SITE_FLAVOR == 'nyaa' %}
 						<li><a href="//{{ config.EXTERNAL_URLS['fap'] }}">Fap</a></li>
 						{% elif config.SITE_FLAVOR == 'sukebei' %}
@@ -216,7 +216,7 @@
 						{% if user_page %}
 						<form class="navbar-form navbar-right form" action="{{ url_for('users.view_user', user_name=user.username) }}" method="get">
 						{% else %}
-						<form class="navbar-form navbar-right form" action="{{ url_for('home') }}" method="get">
+						<form class="navbar-form navbar-right form" action="{{ url_for('main.home') }}" method="get">
 						{% endif %}
 							
 							<input type="text" class="form-control" name="q" placeholder="{{ search_placeholder }}" value="{{ search["term"] if search is defined else '' }}" autofocus>
@@ -252,7 +252,7 @@
 					{% if user_page %}
 					<form class="navbar-form navbar-right form" action="{{ url_for('users.view_user', user_name=user.username) }}" method="get">
 					{% else %}
-					<form class="navbar-form navbar-right form" action="{{ url_for('home') }}" method="get">
+					<form class="navbar-form navbar-right form" action="{{ url_for('main.home') }}" method="get">
 					{% endif %}
 						<div class="input-group search-container hidden-xs hidden-sm">
 							<div class="input-group-btn nav-filter" id="navFilter-criteria">

--- a/nyaa/templates/rss.xml
+++ b/nyaa/templates/rss.xml
@@ -2,8 +2,8 @@
 	<channel>
 		<title>{{ config.SITE_NAME }} Torrent File RSS</title>
 		<description>RSS Feed for {{ term }}</description>
-		<link>{{ url_for('home', _external=True) }}</link>
-		<atom:link href="{{ url_for('home', page='rss', _external=True) }}" rel="self" type="application/rss+xml" />
+		<link>{{ url_for('main.home', _external=True) }}</link>
+		<atom:link href="{{ url_for('main.home', page='rss', _external=True) }}" rel="self" type="application/rss+xml" />
 		{% for torrent in torrent_query %}
 		<item>
 			<title>{{ torrent.display_name }}</title>

--- a/nyaa/templates/search_results.html
+++ b/nyaa/templates/search_results.html
@@ -62,9 +62,9 @@
 				{% set icon_dir = config.SITE_FLAVOR %}
 				<td style="padding:0 4px;">
 				{% if use_elastic %}
-				<a href="{{ url_for('home', c=cat_id) }}" title="{{ category_name(cat_id) }}">
+				<a href="{{ url_for('main.home', c=cat_id) }}" title="{{ category_name(cat_id) }}">
 				{% else %}
-				<a href="{{ url_for('home', c=cat_id) }}" title="{{ torrent.main_category.name }} - {{ torrent.sub_category.name }}">
+				<a href="{{ url_for('main.home', c=cat_id) }}" title="{{ torrent.main_category.name }} - {{ torrent.sub_category.name }}">
 				{% endif %}
 					<img src="{{ url_for('static', filename='img/icons/%s/%s.png'|format(icon_dir, cat_id)) }}" alt="{{ category_name(cat_id) }}">
 				</a>

--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -19,7 +19,7 @@
 		<div class="row">
 			<div class="col-md-1">Category:</div>
 			<div class="col-md-5">
-				<a href="{{ url_for('home', c=torrent.main_category.id_as_string) }}">{{ torrent.main_category.name }}</a> - <a href="{{ url_for('home', c=torrent.sub_category.id_as_string) }}">{{ torrent.sub_category.name }}</a>
+				<a href="{{ url_for('main.home', c=torrent.main_category.id_as_string) }}">{{ torrent.main_category.name }}</a> - <a href="{{ url_for('main.home', c=torrent.sub_category.id_as_string) }}">{{ torrent.sub_category.name }}</a>
 			</div>
 
 			<div class="col-md-1">Date:</div>

--- a/nyaa/views/__init__.py
+++ b/nyaa/views/__init__.py
@@ -1,11 +1,13 @@
 from nyaa.views import (
     account,
     admin,
+    main,
     site,
     users,
 )
 
 account_bp = account.bp
 admin_bp = admin.bp
+main_bp = main.bp
 site_bp = site.bp
 users_bp = users.bp

--- a/nyaa/views/main.py
+++ b/nyaa/views/main.py
@@ -14,6 +14,11 @@ from nyaa.views.account import logout
 bp = flask.Blueprint('main', __name__)
 
 
+@bp.app_errorhandler(404)
+def not_found(error):
+    return flask.render_template('404.html'), 404
+
+
 @bp.before_app_request
 def before_request():
     flask.g.user = None

--- a/nyaa/views/main.py
+++ b/nyaa/views/main.py
@@ -1,0 +1,163 @@
+import math
+import re
+
+import flask
+from flask_paginate import Pagination
+
+from nyaa import app, models
+from nyaa.search import (DEFAULT_MAX_SEARCH_RESULT, DEFAULT_PER_PAGE, SERACH_PAGINATE_DISPLAY_MSG,
+                         _generate_query_string, search_db, search_elastic)
+from nyaa.utils import chain_get
+
+bp = flask.Blueprint('main', __name__)
+
+
+@bp.route('/rss', defaults={'rss': True})
+@bp.route('/', defaults={'rss': False})
+def home(rss):
+    render_as_rss = rss
+    req_args = flask.request.args
+    if req_args.get('page') == 'rss':
+        render_as_rss = True
+
+    search_term = chain_get(req_args, 'q', 'term')
+
+    sort_key = req_args.get('s')
+    sort_order = req_args.get('o')
+
+    category = chain_get(req_args, 'c', 'cats')
+    quality_filter = chain_get(req_args, 'f', 'filter')
+
+    user_name = chain_get(req_args, 'u', 'user')
+    page_number = chain_get(req_args, 'p', 'page', 'offset')
+    try:
+        page_number = max(1, int(page_number))
+    except (ValueError, TypeError):
+        page_number = 1
+
+    # Check simply if the key exists
+    use_magnet_links = 'magnets' in req_args or 'm' in req_args
+
+    results_per_page = app.config.get('RESULTS_PER_PAGE', DEFAULT_PER_PAGE)
+
+    user_id = None
+    if user_name:
+        user = models.User.by_username(user_name)
+        if not user:
+            flask.abort(404)
+        user_id = user.id
+
+    special_results = {
+        'first_word_user': None,
+        'query_sans_user': None,
+        'infohash_torrent': None
+    }
+    # Add advanced features to searches (but not RSS or user searches)
+    if search_term and not render_as_rss and not user_id:
+        # Check if the first word of the search is an existing user
+        user_word_match = re.match(r'^([a-zA-Z0-9_-]+) *(.*|$)', search_term)
+        if user_word_match:
+            special_results['first_word_user'] = models.User.by_username(user_word_match.group(1))
+            special_results['query_sans_user'] = user_word_match.group(2)
+
+        # Check if search is a 40-char torrent hash
+        infohash_match = re.match(r'(?i)^([a-f0-9]{40})$', search_term)
+        if infohash_match:
+            # Check for info hash in database
+            matched_torrent = models.Torrent.by_info_hash_hex(infohash_match.group(1))
+            special_results['infohash_torrent'] = matched_torrent
+
+    query_args = {
+        'user': user_id,
+        'sort': sort_key or 'id',
+        'order': sort_order or 'desc',
+        'category': category or '0_0',
+        'quality_filter': quality_filter or '0',
+        'page': page_number,
+        'rss': render_as_rss,
+        'per_page': results_per_page
+    }
+
+    if flask.g.user:
+        query_args['logged_in_user'] = flask.g.user
+        if flask.g.user.is_moderator:  # God mode
+            query_args['admin'] = True
+
+    infohash_torrent = special_results.get('infohash_torrent')
+    if infohash_torrent:
+        # infohash_torrent is only set if this is not RSS or userpage search
+        flask.flash(flask.Markup('You were redirected here because '
+                                 'the given hash matched this torrent.'), 'info')
+        # Redirect user from search to the torrent if we found one with the specific info_hash
+        return flask.redirect(flask.url_for('view_torrent', torrent_id=infohash_torrent.id))
+
+    # If searching, we get results from elastic search
+    use_elastic = app.config.get('USE_ELASTIC_SEARCH')
+    if use_elastic and search_term:
+        query_args['term'] = search_term
+
+        max_search_results = app.config.get('ES_MAX_SEARCH_RESULT', DEFAULT_MAX_SEARCH_RESULT)
+
+        # Only allow up to (max_search_results / page) pages
+        max_page = min(query_args['page'], int(math.ceil(max_search_results / results_per_page)))
+
+        query_args['page'] = max_page
+        query_args['max_search_results'] = max_search_results
+
+        query_results = search_elastic(**query_args)
+
+        if render_as_rss:
+            return render_rss(
+                '"{}"'.format(search_term), query_results,
+                use_elastic=True, magnet_links=use_magnet_links)
+        else:
+            rss_query_string = _generate_query_string(
+                search_term, category, quality_filter, user_name)
+            max_results = min(max_search_results, query_results['hits']['total'])
+            # change p= argument to whatever you change page_parameter to or pagination breaks
+            pagination = Pagination(p=query_args['page'], per_page=results_per_page,
+                                    total=max_results, bs_version=3, page_parameter='p',
+                                    display_msg=SERACH_PAGINATE_DISPLAY_MSG)
+            return flask.render_template('home.html',
+                                         use_elastic=True,
+                                         pagination=pagination,
+                                         torrent_query=query_results,
+                                         search=query_args,
+                                         rss_filter=rss_query_string,
+                                         special_results=special_results)
+    else:
+        # If ES is enabled, default to db search for browsing
+        if use_elastic:
+            query_args['term'] = ''
+        else:  # Otherwise, use db search for everything
+            query_args['term'] = search_term or ''
+
+        query = search_db(**query_args)
+        if render_as_rss:
+            return render_rss('Home', query, use_elastic=False, magnet_links=use_magnet_links)
+        else:
+            rss_query_string = _generate_query_string(
+                search_term, category, quality_filter, user_name)
+            # Use elastic is always false here because we only hit this section
+            # if we're browsing without a search term (which means we default to DB)
+            # or if ES is disabled
+            return flask.render_template('home.html',
+                                         use_elastic=False,
+                                         torrent_query=query,
+                                         search=query_args,
+                                         rss_filter=rss_query_string,
+                                         special_results=special_results)
+
+
+def render_rss(label, query, use_elastic, magnet_links=False):
+    rss_xml = flask.render_template('rss.xml',
+                                    use_elastic=use_elastic,
+                                    magnet_links=magnet_links,
+                                    term=label,
+                                    site_url=flask.request.url_root,
+                                    torrent_query=query)
+    response = flask.make_response(rss_xml)
+    response.headers['Content-Type'] = 'application/xml'
+    # Cache for an hour
+    response.headers['Cache-Control'] = 'max-age={}'.format(1 * 5 * 60)
+    return response


### PR DESCRIPTION
**_Note:_ This PR is against the 'blueprints' branch.**
[6th pull request out of 8 in total]

    5. Move template filters and globals into blueprint
    6. << This PR >>
    7. Move torrent routes into blueprint
    8. Finish routes.py restructuring process, apply isort and flake8 to package.

This PR moves the following routes into the `main` blueprint (`nyaa/views/main.py`):

* `/`
* `/rss` (alias for `/?page=rss`)

`url_for()`-s in templates and routes were updated.

This also moves the following into the blueprint:

- Related functions/methods:
  * `render_rss()`
- App handlers:
  * `before_request()`
  * `not_found()` (404 error handler)

**Even though this might seem like a big diff**,
most of the code from `routes.py` was copied **in full** into the blueprint.
The only change was to `before_request()` and purely aesthetic, replacing
```python
if not user:
    return views.account.logout()
```
with
```python
# @top of file:  from nyaa.views.account import logout
if not user:
    return logout()
```

***

You can also use git blame to see what code was actually changed by me (and what was plainly copied)
```console
git blame -C HEAD -- nyaa/views/main.py
```

### Testing progress:
- [x] `/` / `/rss`
  - [x] search results (category links)
  - [x] layout (non-user page)
  - [x] rss (links, atom:link)
- [x] `/view/<torrent_id>` (category links)
- [x] `/notarealpage` (something random to trigger 404)
      -- This is added to the tests in a later commit.
- [x] Make sure "before request" handler still works (logging out an invalid user).