### PR TITLE
upload page: use alerts, add alert about rules

### DIFF
--- a/nyaa/templates/upload.html
+++ b/nyaa/templates/upload.html
@@ -19,7 +19,25 @@
 <form method="POST" enctype="multipart/form-data">
 	{{ upload_form.csrf_token }}
 
-	{% if config.ENFORCE_MAIN_ANNOUNCE_URL %}<p><strong>Important:</strong> Please include <kbd>{{ config.MAIN_ANNOUNCE_URL }}</kbd> in your trackers</p>{% endif %}
+	{% if config.ENFORCE_MAIN_ANNOUNCE_URL %}
+	<div class="row">
+		<div class="col-md-10">
+			<div class="alert alert-info" role="alert">
+				<p><strong>Important:</strong> Please include <kbd>{{ config.MAIN_ANNOUNCE_URL }}</kbd> in your trackers</p>
+			</div>
+		</div>
+	</div>
+	{% endif %}
+	<div class="row">
+		<div class="col-md-10">
+			<div class="alert alert-warning" role="alert">
+				<p>Make sure you've read <a href="{{ url_for('site_rules') }}">
+				the rules</a> before uploading your torrent.</p>
+				<p><strong>Only upload torrents for content that originates
+				from and/or is specific to China, Japan, and/or Korea.</strong></p>
+			</div>
+		</div>
+	</div>
 	<div class="row">
 		<div class="col-md-10">
 		{{ render_upload(upload_form.torrent_file, accept=".torrent") }}


### PR DESCRIPTION
This changes the tracker announce URL message to be one of those bootstrap alert bubbles, and adds an additional warning which tells people to read the rules and not upload off-topic crap.

May not be to your liking since it takes up some space.
![upload](https://user-images.githubusercontent.com/308818/28523242-c93c6dee-707b-11e7-93fe-473154f99dd6.png)
