### PR TITLE
[Restructure routes 7] Move torrent routes into blueprint

### DIFF
--- a/nyaa/api_handler.py
+++ b/nyaa/api_handler.py
@@ -109,7 +109,7 @@ def v2_api_upload():
 
         # Create a response dict with relevant data
         torrent_metadata = {
-            'url': flask.url_for('view_torrent', torrent_id=torrent.id, _external=True),
+            'url': flask.url_for('torrents.view', torrent_id=torrent.id, _external=True),
             'id': torrent.id,
             'name': torrent.display_name,
             'hash': torrent.info_hash.hex(),
@@ -306,7 +306,7 @@ def v2_api_info(torrent_id_or_hash):
     # Create a response dict with relevant data
     torrent_metadata = {
         'submitter': submitter,
-        'url': flask.url_for('view_torrent', torrent_id=torrent.id, _external=True),
+        'url': flask.url_for('torrents.view', torrent_id=torrent.id, _external=True),
         'id': torrent.id,
         'name': torrent.display_name,
 

--- a/nyaa/api_handler.py
+++ b/nyaa/api_handler.py
@@ -6,8 +6,7 @@ from nyaa import models, forms
 from nyaa import bencode, backend, utils
 from nyaa import torrents
 
-# For _create_upload_category_choices
-from nyaa import routes
+from nyaa.views.torrents import _create_upload_category_choices
 
 import functools
 import json
@@ -102,7 +101,7 @@ def v2_api_upload():
 
     # Flask-WTF (very helpfully!!) automatically grabs the request form, so force a None formdata
     upload_form = forms.UploadForm(None, data=mapped_dict, meta={'csrf': False})
-    upload_form.category.choices = routes._create_upload_category_choices()
+    upload_form.category.choices = _create_upload_category_choices()
 
     if upload_form.validate():
         torrent = backend.handle_torrent_upload(upload_form, flask.g.user)

--- a/nyaa/backend.py
+++ b/nyaa/backend.py
@@ -12,6 +12,19 @@ from orderedset import OrderedSet
 from ipaddress import ip_address
 
 
+@utils.cached_function
+def get_category_id_map():
+    ''' Reads database for categories and turns them into a dict with
+        ids as keys and name list as the value, ala
+        {'1_0': ['Anime'], '1_2': ['Anime', 'English-translated'], ...} '''
+    cat_id_map = {}
+    for main_cat in models.MainCategory.query:
+        cat_id_map[main_cat.id_as_string] = [main_cat.name]
+        for sub_cat in main_cat.sub_categories:
+            cat_id_map[sub_cat.id_as_string] = [main_cat.name, sub_cat.name]
+    return cat_id_map
+
+
 def _replace_utf8_values(dict_or_list):
     ''' Will replace 'property' with 'property.utf-8' and remove latter if it exists.
         Thanks, bitcomet! :/ '''

--- a/nyaa/routes.py
+++ b/nyaa/routes.py
@@ -1,6 +1,4 @@
-import flask
-
-from nyaa import api_handler, app, db, forms, models, template_utils, views
+from nyaa import api_handler, app, template_utils, views
 from nyaa.backend import get_category_id_map
 
 DEBUG_API = False
@@ -10,61 +8,6 @@ DEBUG_API = False
 def category_name(cat_id):
     ''' Given a category id (eg. 1_2), returns a category name (eg. Anime - English-translated) '''
     return ' - '.join(get_category_id_map().get(cat_id, ['???']))
-
-
-# Routes start here #
-
-@app.route('/view/<int:torrent_id>/comment/<int:comment_id>/delete', methods=['POST'])
-def delete_comment(torrent_id, comment_id):
-    if not flask.g.user:
-        flask.abort(403)
-    torrent = models.Torrent.by_id(torrent_id)
-    if not torrent:
-        flask.abort(404)
-
-    comment = models.Comment.query.filter_by(id=comment_id).first()
-    if not comment:
-        flask.abort(404)
-
-    if not (comment.user.id == flask.g.user.id or flask.g.user.is_moderator):
-        flask.abort(403)
-
-    db.session.delete(comment)
-    db.session.flush()
-    torrent.update_comment_count()
-
-    url = flask.url_for('torrents.view', torrent_id=torrent.id)
-    if flask.g.user.is_moderator:
-        log = "Comment deleted on torrent [#{}]({})".format(torrent.id, url)
-        adminlog = models.AdminLog(log=log, admin_id=flask.g.user.id)
-        db.session.add(adminlog)
-    db.session.commit()
-
-    flask.flash('Comment successfully deleted.', 'success')
-
-    return flask.redirect(url)
-
-
-@app.route('/view/<int:torrent_id>/submit_report', methods=['POST'])
-def submit_report(torrent_id):
-    if not flask.g.user:
-        flask.abort(403)
-
-    form = forms.ReportForm(flask.request.form)
-
-    if flask.request.method == 'POST' and form.validate():
-        report_reason = form.reason.data
-        current_user_id = flask.g.user.id
-        report = models.Report(
-            torrent_id=torrent_id,
-            user_id=current_user_id,
-            reason=report_reason)
-
-        db.session.add(report)
-        db.session.commit()
-        flask.flash('Successfully reported torrent!', 'success')
-
-    return flask.redirect(flask.url_for('torrents.view', torrent_id=torrent_id))
 
 
 # #################################### BLUEPRINTS ####################################

--- a/nyaa/routes.py
+++ b/nyaa/routes.py
@@ -1,9 +1,6 @@
-import os.path
-from urllib.parse import quote
-
 import flask
 
-from nyaa import api_handler, app, db, forms, models, template_utils, torrents, views
+from nyaa import api_handler, app, db, forms, models, template_utils, views
 from nyaa.backend import get_category_id_map
 
 DEBUG_API = False
@@ -48,32 +45,6 @@ def delete_comment(torrent_id, comment_id):
     return flask.redirect(url)
 
 
-@app.route('/view/<int:torrent_id>/magnet')
-def redirect_magnet(torrent_id):
-    torrent = models.Torrent.by_id(torrent_id)
-
-    if not torrent:
-        flask.abort(404)
-
-    return flask.redirect(torrents.create_magnet(torrent))
-
-
-@app.route('/view/<int:torrent_id>/torrent')
-@app.route('/download/<int:torrent_id>.torrent')
-def download_torrent(torrent_id):
-    torrent = models.Torrent.by_id(torrent_id)
-
-    if not torrent or not torrent.has_torrent:
-        flask.abort(404)
-
-    resp = flask.Response(_get_cached_torrent_file(torrent))
-    resp.headers['Content-Type'] = 'application/x-bittorrent'
-    resp.headers['Content-Disposition'] = 'inline; filename="{0}"; filename*=UTF-8\'\'{0}'.format(
-        quote(torrent.torrent_name.encode('utf-8')))
-
-    return resp
-
-
 @app.route('/view/<int:torrent_id>/submit_report', methods=['POST'])
 def submit_report(torrent_id):
     if not flask.g.user:
@@ -94,17 +65,6 @@ def submit_report(torrent_id):
         flask.flash('Successfully reported torrent!', 'success')
 
     return flask.redirect(flask.url_for('torrents.view', torrent_id=torrent_id))
-
-
-def _get_cached_torrent_file(torrent):
-    # Note: obviously temporary
-    cached_torrent = os.path.join(app.config['BASE_DIR'],
-                                  'torrent_cache', str(torrent.id) + '.torrent')
-    if not os.path.exists(cached_torrent):
-        with open(cached_torrent, 'wb') as out_file:
-            out_file.write(torrents.create_bencoded_torrent(torrent))
-
-    return open(cached_torrent, 'rb')
 
 
 # #################################### BLUEPRINTS ####################################

--- a/nyaa/templates/edit.html
+++ b/nyaa/templates/edit.html
@@ -4,7 +4,7 @@
 {% from "_formhelpers.html" import render_field %}
 {% from "_formhelpers.html" import render_markdown_editor %}
 
-{% set torrent_url = url_for('view_torrent', torrent_id=torrent.id) %}
+{% set torrent_url = url_for('torrents.view', torrent_id=torrent.id) %}
 <h1>
 	Edit Torrent <a href="{{ torrent_url }}">#{{torrent.id}}</a>
 	{% if (torrent.user != None) and (torrent.user != g.user) %}

--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -71,7 +71,7 @@
 				{% set search_placeholder = 'Search {} torrents...'.format(search_username) if user_page else 'Search...' %}
 				<div id="navbar" class="navbar-collapse collapse">
 					<ul class="nav navbar-nav">
-						<li {% if request.path == url_for('upload') %}class="active"{% endif %}><a href="{{ url_for('upload') }}">Upload</a></li>
+						<li {% if request.path == url_for('torrents.upload') %}class="active"{% endif %}><a href="{{ url_for('torrents.upload') }}">Upload</a></li>
 						<li class="dropdown">
 							<a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
 								About

--- a/nyaa/templates/reports.html
+++ b/nyaa/templates/reports.html
@@ -25,7 +25,7 @@
 					{% endif %}
 				</td>
 				<td>
-					<a href="{{ url_for('view_torrent', torrent_id=report.torrent.id) }}">{{ report.torrent.display_name }}</a>
+					<a href="{{ url_for('torrents.view', torrent_id=report.torrent.id) }}">{{ report.torrent.display_name }}</a>
 					by <a href="{{ url_for('users.view_user', user_name=report.torrent.user.username) }}">
 					{{ report.torrent.user.username }}</a>
 					{% if g.user.is_superadmin and report.torrent.uploader_ip %}

--- a/nyaa/templates/rss.xml
+++ b/nyaa/templates/rss.xml
@@ -14,7 +14,7 @@
 				{% else %}
 				<link>{{ create_magnet_from_es_info(torrent.display_name, torrent.info_hash) }}</link>
 				{% endif %}
-				<guid isPermaLink="true">{{ url_for('view_torrent', torrent_id=torrent.meta.id, _external=True) }}</guid>
+				<guid isPermaLink="true">{{ url_for('torrents.view', torrent_id=torrent.meta.id, _external=True) }}</guid>
 				<pubDate>{{ torrent.created_time|rfc822_es }}</pubDate>
 
 				<nyaa:seeders>  {{- torrent.seed_count     }}</nyaa:seeders>
@@ -27,7 +27,7 @@
 				{% else %}
 				<link>{{ torrent.magnet_uri }}</link>
 				{% endif %}
-				<guid isPermaLink="true">{{ url_for('view_torrent', torrent_id=torrent.id, _external=True) }}</guid>
+				<guid isPermaLink="true">{{ url_for('torrents.view', torrent_id=torrent.id, _external=True) }}</guid>
 				<pubDate>{{ torrent.created_time|rfc822 }}</pubDate>
 
 				<nyaa:seeders>  {{- torrent.stats.seed_count     }}</nyaa:seeders>

--- a/nyaa/templates/rss.xml
+++ b/nyaa/templates/rss.xml
@@ -10,7 +10,7 @@
 			{# <description><![CDATA[{{ torrent.description }}]]></description> #}
 			{% if use_elastic %}
 				{% if torrent.has_torrent and not magnet_links %}
-				<link>{{ url_for('download_torrent', torrent_id=torrent.meta.id, _external=True) }}</link>
+				<link>{{ url_for('torrents.download', torrent_id=torrent.meta.id, _external=True) }}</link>
 				{% else %}
 				<link>{{ create_magnet_from_es_info(torrent.display_name, torrent.info_hash) }}</link>
 				{% endif %}
@@ -23,7 +23,7 @@
 				<nyaa:infoHash> {{- torrent.info_hash      }}</nyaa:infoHash>
 			{% else %}
 				{% if torrent.has_torrent and not magnet_links %}
-				<link>{{ url_for('download_torrent', torrent_id=torrent.id, _external=True) }}</link>
+				<link>{{ url_for('torrents.download', torrent_id=torrent.id, _external=True) }}</link>
 				{% else %}
 				<link>{{ torrent.magnet_uri }}</link>
 				{% endif %}

--- a/nyaa/templates/search_results.html
+++ b/nyaa/templates/search_results.html
@@ -84,7 +84,7 @@
 					{% endif %}
 				</td>
 				<td class="text-center" style="white-space: nowrap;">
-					{% if torrent.has_torrent %}<a href="{{ url_for('download_torrent', torrent_id=torrent_id) }}"><i class="fa fa-fw fa-download"></i></a>{% endif %}
+					{% if torrent.has_torrent %}<a href="{{ url_for('torrents.download', torrent_id=torrent_id) }}"><i class="fa fa-fw fa-download"></i></a>{% endif %}
 					{% if use_elastic %}
 					<a href="{{ create_magnet_from_es_info(torrent.display_name, torrent.info_hash) }}"><i class="fa fa-fw fa-magnet"></i></a>
 					{% else %}

--- a/nyaa/templates/search_results.html
+++ b/nyaa/templates/search_results.html
@@ -73,14 +73,14 @@
 					{% set torrent_id = torrent.meta.id if use_elastic else torrent.id %}
 					{% set com_count = torrent.comment_count %}
 					{% if com_count %}
-					<a href="{{ url_for('view_torrent', torrent_id=torrent_id, _anchor='comments') }}" class="comments" title="{{ '{c} comment{s}'.format(c=com_count, s='s' if com_count > 1 else '') }}">
+					<a href="{{ url_for('torrents.view', torrent_id=torrent_id, _anchor='comments') }}" class="comments" title="{{ '{c} comment{s}'.format(c=com_count, s='s' if com_count > 1 else '') }}">
 						<i class="fa fa-comments-o"></i>{{ com_count -}}
 					</a>
 					{% endif %}
 					{% if use_elastic %}
-					<a href="{{ url_for('view_torrent', torrent_id=torrent_id) }}" title="{{ torrent.display_name | escape }}">{%if "highlight" in torrent.meta %}{{ torrent.meta.highlight.display_name[0] | safe }}{% else %}{{torrent.display_name}}{%endif%}</a>
+					<a href="{{ url_for('torrents.view', torrent_id=torrent_id) }}" title="{{ torrent.display_name | escape }}">{%if "highlight" in torrent.meta %}{{ torrent.meta.highlight.display_name[0] | safe }}{% else %}{{torrent.display_name}}{%endif%}</a>
 					{% else %}
-					<a href="{{ url_for('view_torrent', torrent_id=torrent_id) }}" title="{{ torrent.display_name | escape }}">{{ torrent.display_name | escape }}</a>
+					<a href="{{ url_for('torrents.view', torrent_id=torrent_id) }}" title="{{ torrent.display_name | escape }}">{{ torrent.display_name | escape }}</a>
 					{% endif %}
 				</td>
 				<td class="text-center" style="white-space: nowrap;">

--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -73,7 +73,7 @@
 	</div><!--/.panel-body -->
 
 	<div class="panel-footer clearfix">
-		{% if torrent.has_torrent %}<a href="{{ url_for('download_torrent', torrent_id=torrent.id )}}"><i class="fa fa-download fa-fw"></i>Download Torrent</a> or {% endif %}<a href="{{ torrent.magnet_uri }}" class="card-footer-item"><i class="fa fa-magnet fa-fw"></i>Magnet</a>
+		{% if torrent.has_torrent %}<a href="{{ url_for('torrents.download', torrent_id=torrent.id )}}"><i class="fa fa-download fa-fw"></i>Download Torrent</a> or {% endif %}<a href="{{ torrent.magnet_uri }}" class="card-footer-item"><i class="fa fa-magnet fa-fw"></i>Magnet</a>
 		{% if g.user %}
 		<button type="button" class="btn btn-xs btn-danger pull-right" data-toggle="modal" data-target="#reportModal">
 			Report

--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -10,7 +10,7 @@
 	<div class="panel-heading"{% if torrent.hidden %} style="background-color: darkgray;"{% endif %}>
 		<h3 class="panel-title">
 			{% if can_edit %}
-			<a href="{{ url_for('edit_torrent', torrent_id=torrent.id) }}" title="Edit torrent"><i class="fa fa-fw fa-pencil"></i></a>
+			<a href="{{ url_for('torrents.edit', torrent_id=torrent.id) }}" title="Edit torrent"><i class="fa fa-fw fa-pencil"></i></a>
 			{% endif %}
 			{{ torrent.display_name }}
 		</h3>

--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -156,7 +156,7 @@
 				<div class="row">
 					<a href="#com-{{ loop.index }}"><small data-timestamp-swap data-timestamp="{{ comment.created_utc_timestamp|int }}">{{ comment.created_time.strftime('%Y-%m-%d %H:%M UTC') }}</small></a>
 					{% if g.user.is_moderator or g.user.id == comment.user_id %}
-					<form class="delete-comment-form" action="{{ url_for('delete_comment', torrent_id=torrent.id, comment_id=comment.id) }}" method="POST">
+					<form class="delete-comment-form" action="{{ url_for('torrents.delete_comment', torrent_id=torrent.id, comment_id=comment.id) }}" method="POST">
 						<button name="submit" type="submit" class="btn btn-danger btn-xs" title="Delete">Delete</button>
 					</form>
 					{% endif %}
@@ -195,7 +195,7 @@
 					rules</a>. Useless reports like "download is slow" or
 					"thanks" can get you banned from the site.
 				</div>
-				<form method="POST" action="{{ request.url }}/submit_report">
+				<form method="POST" action="{{ url_for('torrents.report', torrent_id=torrent.id) }}">
 					{{ report_form.csrf_token }}
 					{{ render_field(report_form.reason, class_='form-control', maxlength=255) }}
 					<div style="float: right;">

--- a/nyaa/views/__init__.py
+++ b/nyaa/views/__init__.py
@@ -3,6 +3,7 @@ from nyaa.views import (
     admin,
     main,
     site,
+    torrents,
     users,
 )
 
@@ -10,4 +11,5 @@ account_bp = account.bp
 admin_bp = admin.bp
 main_bp = main.bp
 site_bp = site.bp
+torrents_bp = torrents.bp
 users_bp = users.bp

--- a/nyaa/views/admin.py
+++ b/nyaa/views/admin.py
@@ -44,19 +44,19 @@ def view_reports():
                 torrent.deleted = True
                 report.status = 1
                 log = log.format(report_id, 'Deleted', torrent_id,
-                                 flask.url_for('view_torrent', torrent_id=torrent_id),
+                                 flask.url_for('torrents.view', torrent_id=torrent_id),
                                  report_user.username,
                                  flask.url_for('users.view_user', user_name=report_user.username))
             elif action == 'hide':
                 log = log.format(report_id, 'Hid', torrent_id,
-                                 flask.url_for('view_torrent', torrent_id=torrent_id),
+                                 flask.url_for('torrents.view', torrent_id=torrent_id),
                                  report_user.username,
                                  flask.url_for('users.view_user', user_name=report_user.username))
                 torrent.hidden = True
                 report.status = 1
             else:
                 log = log.format(report_id, 'Closed', torrent_id,
-                                 flask.url_for('view_torrent', torrent_id=torrent_id),
+                                 flask.url_for('torrents.view', torrent_id=torrent_id),
                                  report_user.username,
                                  flask.url_for('users.view_user', user_name=report_user.username))
                 report.status = 2

--- a/nyaa/views/main.py
+++ b/nyaa/views/main.py
@@ -115,7 +115,7 @@ def home(rss):
         flask.flash(flask.Markup('You were redirected here because '
                                  'the given hash matched this torrent.'), 'info')
         # Redirect user from search to the torrent if we found one with the specific info_hash
-        return flask.redirect(flask.url_for('view_torrent', torrent_id=infohash_torrent.id))
+        return flask.redirect(flask.url_for('torrents.view', torrent_id=infohash_torrent.id))
 
     # If searching, we get results from elastic search
     use_elastic = app.config.get('USE_ELASTIC_SEARCH')

--- a/nyaa/views/torrents.py
+++ b/nyaa/views/torrents.py
@@ -174,6 +174,59 @@ def download_torrent(torrent_id):
     return resp
 
 
+@bp.route('/view/<int:torrent_id>/comment/<int:comment_id>/delete', methods=['POST'])
+def delete_comment(torrent_id, comment_id):
+    if not flask.g.user:
+        flask.abort(403)
+    torrent = models.Torrent.by_id(torrent_id)
+    if not torrent:
+        flask.abort(404)
+
+    comment = models.Comment.query.filter_by(id=comment_id).first()
+    if not comment:
+        flask.abort(404)
+
+    if not (comment.user.id == flask.g.user.id or flask.g.user.is_moderator):
+        flask.abort(403)
+
+    db.session.delete(comment)
+    db.session.flush()
+    torrent.update_comment_count()
+
+    url = flask.url_for('torrents.view', torrent_id=torrent.id)
+    if flask.g.user.is_moderator:
+        log = "Comment deleted on torrent [#{}]({})".format(torrent.id, url)
+        adminlog = models.AdminLog(log=log, admin_id=flask.g.user.id)
+        db.session.add(adminlog)
+    db.session.commit()
+
+    flask.flash('Comment successfully deleted.', 'success')
+
+    return flask.redirect(url)
+
+
+@bp.route('/view/<int:torrent_id>/submit_report', endpoint='report', methods=['POST'])
+def submit_report(torrent_id):
+    if not flask.g.user:
+        flask.abort(403)
+
+    form = forms.ReportForm(flask.request.form)
+
+    if flask.request.method == 'POST' and form.validate():
+        report_reason = form.reason.data
+        current_user_id = flask.g.user.id
+        report = models.Report(
+            torrent_id=torrent_id,
+            user_id=current_user_id,
+            reason=report_reason)
+
+        db.session.add(report)
+        db.session.commit()
+        flask.flash('Successfully reported torrent!', 'success')
+
+    return flask.redirect(flask.url_for('torrents.view', torrent_id=torrent_id))
+
+
 @bp.route('/upload', methods=['GET', 'POST'])
 def upload():
     upload_form = forms.UploadForm(CombinedMultiDict((flask.request.files, flask.request.form)))

--- a/nyaa/views/torrents.py
+++ b/nyaa/views/torrents.py
@@ -1,10 +1,12 @@
 import json
 
 import flask
+from werkzeug.datastructures import CombinedMultiDict
 
 from sqlalchemy.orm import joinedload
 
-from nyaa import db, forms, models
+from nyaa import backend, db, forms, models
+from nyaa.utils import cached_function
 
 bp = flask.Blueprint('torrents', __name__)
 
@@ -68,3 +70,108 @@ def view_torrent(torrent_id):
                                  comments=torrent.comments,
                                  can_edit=can_edit,
                                  report_form=report_form)
+
+
+@bp.route('/view/<int:torrent_id>/edit', endpoint='edit', methods=['GET', 'POST'])
+def edit_torrent(torrent_id):
+    torrent = models.Torrent.by_id(torrent_id)
+    form = forms.EditForm(flask.request.form)
+    form.category.choices = _create_upload_category_choices()
+
+    editor = flask.g.user
+
+    if not torrent:
+        flask.abort(404)
+
+    # Only allow admins edit deleted torrents
+    if torrent.deleted and not (editor and editor.is_moderator):
+        flask.abort(404)
+
+    # Only allow torrent owners or admins edit torrents
+    if not editor or not (editor is torrent.user or editor.is_moderator):
+        flask.abort(403)
+
+    if flask.request.method == 'POST' and form.validate():
+        # Form has been sent, edit torrent with data.
+        torrent.main_category_id, torrent.sub_category_id = \
+            form.category.parsed_data.get_category_ids()
+        torrent.display_name = (form.display_name.data or '').strip()
+        torrent.information = (form.information.data or '').strip()
+        torrent.description = (form.description.data or '').strip()
+
+        torrent.hidden = form.is_hidden.data
+        torrent.remake = form.is_remake.data
+        torrent.complete = form.is_complete.data
+        torrent.anonymous = form.is_anonymous.data
+
+        if editor.is_trusted:
+            torrent.trusted = form.is_trusted.data
+
+        deleted_changed = torrent.deleted != form.is_deleted.data
+        if editor.is_moderator:
+            torrent.deleted = form.is_deleted.data
+
+        url = flask.url_for('torrents.view', torrent_id=torrent.id)
+        if deleted_changed and editor.is_moderator:
+            log = "Torrent [#{0}]({1}) marked as {2}".format(
+                torrent.id, url, "deleted" if torrent.deleted else "undeleted")
+            adminlog = models.AdminLog(log=log, admin_id=editor.id)
+            db.session.add(adminlog)
+
+        db.session.commit()
+
+        flask.flash(flask.Markup(
+            'Torrent has been successfully edited! Changes might take a few minutes to show up.'),
+            'info')
+
+        return flask.redirect(url)
+    else:
+        if flask.request.method != 'POST':
+            # Fill form data only if the POST didn't fail
+            form.category.data = torrent.sub_category.id_as_string
+            form.display_name.data = torrent.display_name
+            form.information.data = torrent.information
+            form.description.data = torrent.description
+
+            form.is_hidden.data = torrent.hidden
+            form.is_remake.data = torrent.remake
+            form.is_complete.data = torrent.complete
+            form.is_anonymous.data = torrent.anonymous
+
+            form.is_trusted.data = torrent.trusted
+            form.is_deleted.data = torrent.deleted
+
+        return flask.render_template('edit.html',
+                                     form=form,
+                                     torrent=torrent)
+
+
+@bp.route('/upload', methods=['GET', 'POST'])
+def upload():
+    upload_form = forms.UploadForm(CombinedMultiDict((flask.request.files, flask.request.form)))
+    upload_form.category.choices = _create_upload_category_choices()
+
+    if flask.request.method == 'POST' and upload_form.validate():
+        torrent = backend.handle_torrent_upload(upload_form, flask.g.user)
+
+        return flask.redirect(flask.url_for('torrents.view', torrent_id=torrent.id))
+    else:
+        # If we get here with a POST, it means the form data was invalid: return a non-okay status
+        status_code = 400 if flask.request.method == 'POST' else 200
+        return flask.render_template('upload.html', upload_form=upload_form), status_code
+
+
+@cached_function
+def _create_upload_category_choices():
+    ''' Turns categories in the database into a list of (id, name)s '''
+    choices = [('', '[Select a category]')]
+    id_map = backend.get_category_id_map()
+
+    for key in sorted(id_map.keys()):
+        cat_names = id_map[key]
+        is_main_cat = key.endswith('_0')
+
+        # cat_name = is_main_cat and cat_names[0] or (' - ' + cat_names[1])
+        cat_name = ' - '.join(cat_names)
+        choices.append((key, cat_name, is_main_cat))
+    return choices

--- a/nyaa/views/torrents.py
+++ b/nyaa/views/torrents.py
@@ -1,0 +1,70 @@
+import json
+
+import flask
+
+from sqlalchemy.orm import joinedload
+
+from nyaa import db, forms, models
+
+bp = flask.Blueprint('torrents', __name__)
+
+
+@bp.route('/view/<int:torrent_id>', endpoint='view', methods=['GET', 'POST'])
+def view_torrent(torrent_id):
+    if flask.request.method == 'POST':
+        torrent = models.Torrent.by_id(torrent_id)
+    else:
+        torrent = models.Torrent.query \
+                                .options(joinedload('filelist'),
+                                         joinedload('comments')) \
+                                .filter_by(id=torrent_id) \
+                                .first()
+    if not torrent:
+        flask.abort(404)
+
+    # Only allow admins see deleted torrents
+    if torrent.deleted and not (flask.g.user and flask.g.user.is_moderator):
+        flask.abort(404)
+
+    comment_form = None
+    if flask.g.user:
+        comment_form = forms.CommentForm()
+
+    if flask.request.method == 'POST':
+        if not flask.g.user:
+            flask.abort(403)
+
+        if comment_form.validate():
+            comment_text = (comment_form.comment.data or '').strip()
+
+            comment = models.Comment(
+                torrent_id=torrent_id,
+                user_id=flask.g.user.id,
+                text=comment_text)
+
+            db.session.add(comment)
+            db.session.flush()
+
+            torrent_count = torrent.update_comment_count()
+            db.session.commit()
+
+            flask.flash('Comment successfully posted.', 'success')
+
+            return flask.redirect(flask.url_for('torrents.view',
+                                                torrent_id=torrent_id,
+                                                _anchor='com-' + str(torrent_count)))
+
+    # Only allow owners and admins to edit torrents
+    can_edit = flask.g.user and (flask.g.user is torrent.user or flask.g.user.is_moderator)
+
+    files = None
+    if torrent.filelist:
+        files = json.loads(torrent.filelist.filelist_blob.decode('utf-8'))
+
+    report_form = forms.ReportForm()
+    return flask.render_template('view.html', torrent=torrent,
+                                 files=files,
+                                 comment_form=comment_form,
+                                 comments=torrent.comments,
+                                 can_edit=can_edit,
+                                 report_form=report_form)


### PR DESCRIPTION
**_Note:_ This PR is against the 'blueprints' branch.**
[7th pull request out of 8 in total]

    6. Move home, RSS and request handlers into blueprint
    7. << This PR >>
    8. Finish routes.py restructuring process

This PR moves the following routes into the `torrents` blueprint (`nyaa/views/torrents.py`):

* `/upload`
* `/view/<int:torrent_id>`
* `/view/<int:torrent_id>/edit`
* `/view/<int:torrent_id>/magnet`
* `/download/<int:torrent_id>.torrent` (+ alias: `/view/<int:torrent_id>/torrent`)
* `/view/<int:torrent_id>/submit_report`
* `/view/<int:torrent_id>/comment/<int:comment_id>/delete`

`url_for()`-s in templates and routes were updated.

This also moves supporting methods/functions into other files:
* Into `nyaa.backend`:
  - `get_category_id_map()`
* Into the blueprint `nyaa.views.torrents`:
  - `_create_upload_category_choices()`

**Notes:**
* Like before, most of the code from `routes.py` was copied **in full** into the blueprint.
  The only changes made to the torrent routes are as follows:
  - Added an `endpoint` parameters to the following routes (to make url_for nicer)
    * `view_torrent` => `torrents.view`
    * `edit_torrent` => `torrents.edit`
    * `download_torrent` => `torrents.download`
    * `submit_report` => `torrents.report`
  - Fixed missing `flask.url_for` in the upload route redirection
     (was `return flask.redirect('/view/' + str(torrent.id))`)
  - Updated `flask.url_for()` within the routes
* Some changes made to the master branch are not in this branch (to keep things simple).
  **I am keeping track of every commit that affects the blueprints branch,
  and will be fixing the conflicts in the PR from `blueprints` to `master`.** 

***

You can also use git blame to see what code was actually changed by me (and what was plainly copied)
```console
git blame -C HEAD -- nyaa/views/torrents.py
```

### Testing progress:
- [x] Making sure every endpoint's generated url is correct.
- [x] GET `/upload`
- [x] POST `/upload`
- [x] GET `/view/<int:torrent_id>`
- [x] POST `/view/<int:torrent_id>` (comment)
- [x] GET `/view/<int:torrent_id>/edit`
- [x] POST `/view/<int:torrent_id>/edit`
- [x] GET `/view/<int:torrent_id>/magnet` (unused, but still)
- [x] GET `/download/<int:torrent_id>.torrent`
- [x] GET `/view/<int:torrent_id>/torrent` (alias)
- [x] POST `/view/<int:torrent_id>/submit_report`
- [x] POST `/view/<int:torrent_id>/comment/<int:comment_id>/delete`