### PR TITLE
[Restructure routes 8] Finish routes.py restructuring process

### DIFF
--- a/nyaa/routes.py
+++ b/nyaa/routes.py
@@ -1,13 +1,6 @@
 from nyaa import api_handler, app, template_utils, views
-from nyaa.backend import get_category_id_map
 
 DEBUG_API = False
-
-
-@app.template_global()
-def category_name(cat_id):
-    ''' Given a category id (eg. 1_2), returns a category name (eg. Anime - English-translated) '''
-    return ' - '.join(get_category_id_map().get(cat_id, ['???']))
 
 
 # #################################### BLUEPRINTS ####################################

--- a/nyaa/routes.py
+++ b/nyaa/routes.py
@@ -1,25 +1,9 @@
-from nyaa import api_handler, app, template_utils, views
+from nyaa import app, template_utils, views
+from nyaa.api_handler import api_blueprint
 
-DEBUG_API = False
-
-
-# #################################### BLUEPRINTS ####################################
-
-def register_blueprints(flask_app):
-    """ Register the blueprints using the flask_app object """
-
-    # Template filters and globals
-    flask_app.register_blueprint(template_utils.bp)
-    # API routes
-    flask_app.register_blueprint(api_handler.api_blueprint, url_prefix='/api')
-    # Site routes
-    flask_app.register_blueprint(views.account_bp)
-    flask_app.register_blueprint(views.admin_bp)
-    flask_app.register_blueprint(views.main_bp)
-    flask_app.register_blueprint(views.site_bp)
-    flask_app.register_blueprint(views.torrents_bp)
-    flask_app.register_blueprint(views.users_bp)
-
-
-# When done, this can be moved to nyaa/__init__.py instead of importing this file
-register_blueprints(app)
+# Register all template filters and template globals
+app.register_blueprint(template_utils.bp)
+# Register the API routes
+app.register_blueprint(api_blueprint, url_prefix='/api')
+# Register the site's routes
+views.register(app)

--- a/nyaa/template_utils.py
+++ b/nyaa/template_utils.py
@@ -6,6 +6,7 @@ import flask
 from werkzeug.urls import url_encode
 
 from nyaa import app
+from nyaa.backend import get_category_id_map
 
 bp = flask.Blueprint('template-utils', __name__)
 _static_cache = {}  # For static_cachebuster
@@ -52,6 +53,12 @@ def filter_truthy(input_list):
     """ Jinja2 can't into list comprehension so this is for
         the search_results.html template """
     return [item for item in input_list if item]
+
+
+@bp.app_template_global()
+def category_name(cat_id):
+    """ Given a category id (eg. 1_2), returns a category name (eg. Anime - English-translated) """
+    return ' - '.join(get_category_id_map().get(cat_id, ['???']))
 
 
 # ######################### TEMPLATE FILTERS #########################

--- a/nyaa/views/__init__.py
+++ b/nyaa/views/__init__.py
@@ -7,9 +7,12 @@ from nyaa.views import (
     users,
 )
 
-account_bp = account.bp
-admin_bp = admin.bp
-main_bp = main.bp
-site_bp = site.bp
-torrents_bp = torrents.bp
-users_bp = users.bp
+
+def register(flask_app):
+    """ Register the blueprints using the flask_app object """
+    flask_app.register_blueprint(account.bp)
+    flask_app.register_blueprint(admin.bp)
+    flask_app.register_blueprint(main.bp)
+    flask_app.register_blueprint(site.bp)
+    flask_app.register_blueprint(torrents.bp)
+    flask_app.register_blueprint(users.bp)

--- a/tests/test_template_utils.py
+++ b/tests/test_template_utils.py
@@ -4,9 +4,8 @@ import datetime
 from email.utils import formatdate
 
 from tests import NyaaTestCase
-from nyaa.routes import category_name
 from nyaa.template_utils import (_jinja2_filter_rfc822, _jinja2_filter_rfc822_es, get_utc_timestamp,
-                                 get_display_time, timesince, filter_truthy)
+                                 get_display_time, timesince, filter_truthy, category_name)
 
 
 class TestTemplateUtils(NyaaTestCase):


### PR DESCRIPTION
**_Note:_ This PR is against the 'blueprints' branch.**
[8th pull request out of 8 in total]

    7. Move torrent routes into blueprint
    8. << This PR >>

Changes in this PR:
- Move the remaining template_global - `category_name`
  into 'template-utils' blueprint (`nyaa/template_utils.py`)
  Function code remains unchanged apart from replacing single quotes.
- Refactor routes.py in preparation for next steps (app factory)
  - Add `register()` method (`nyaa/views/__init__.py`)
  - Import and register blueprints using top-level statements (`nyaa/routes.py`)
  - Remove unused variable: `DEBUG_API`
- This also updates the import line in the `tests/test_template_utils.py` file, so the tests could still pass.

### Testing progress:
- [x] Simple - make sure the app still runs after the refactor to `nyaa/routes.py`
- [x] Test `category_name` global by rendering a template (`search_results.html` / `rss.xml`)