### PR TITLE
[DB Schema change] Webseed support

### DIFF
--- a/migrations/versions/ffd23e570f92_add_is_webseed_to_trackers.py
+++ b/migrations/versions/ffd23e570f92_add_is_webseed_to_trackers.py
@@ -1,0 +1,24 @@
+"""Add is_webseed to Trackers
+
+Revision ID: ffd23e570f92
+Revises: 1add911660a6
+Create Date: 2017-07-29 19:03:58.244769
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'ffd23e570f92'
+down_revision = '1add911660a6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('trackers', sa.Column('is_webseed', sa.Boolean(), nullable=False))
+
+
+def downgrade():
+    op.drop_column('trackers', 'is_webseed')

--- a/nyaa/forms.py
+++ b/nyaa/forms.py
@@ -343,6 +343,16 @@ def _validate_trackers(torrent_dict, tracker_to_check_for=None):
     return tracker_found
 
 
+# http://www.bittorrent.org/beps/bep_0019.html
+def _validate_webseeds(torrent_dict):
+    webseed_list = torrent_dict.get('url-list')
+    if webseed_list is not None:
+        _validate_list(webseed_list, 'url-list')
+
+        for webseed_url in webseed_list:
+            _validate_bytes(webseed_url, 'url-list item', test_decode='utf-8')
+
+
 def _validate_torrent_metadata(torrent_dict):
     ''' Validates a torrent metadata dict, raising AssertionError on errors '''
     assert isinstance(torrent_dict, dict), 'torrent metadata is not a dict'
@@ -383,6 +393,8 @@ def _validate_torrent_metadata(torrent_dict):
     else:
         length = info_dict.get('length')
         _validate_number(length, 'length', check_positive=True)
+
+    _validate_webseeds(torrent_dict)
 
 
 def _validate_bytes(value, name='value', check_empty=True, test_decode=None):

--- a/nyaa/models.py
+++ b/nyaa/models.py
@@ -327,6 +327,7 @@ class Trackers(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     uri = db.Column(db.String(length=255, collation=COL_UTF8_GENERAL_CI),
                     nullable=False, unique=True)
+    is_webseed = db.Column(db.Boolean, nullable=False, default=False)
     disabled = db.Column(db.Boolean, nullable=False, default=False)
 
     @classmethod

--- a/nyaa/torrents.py
+++ b/nyaa/torrents.py
@@ -37,8 +37,9 @@ def default_trackers():
     return USED_TRACKERS[:]
 
 
-def get_trackers(torrent):
+def get_trackers_and_webseeds(torrent):
     trackers = OrderedSet()
+    webseeds = OrderedSet()
 
     # Our main one first
     main_announce_url = app.config.get('MAIN_ANNOUNCE_URL')
@@ -46,14 +47,20 @@ def get_trackers(torrent):
         trackers.add(main_announce_url)
 
     # then the user ones
-    torrent_trackers = torrent.trackers
+    torrent_trackers = torrent.trackers  # here be webseeds too
     for torrent_tracker in torrent_trackers:
-        trackers.add(torrent_tracker.tracker.uri)
+        tracker = torrent_tracker.tracker
+
+        # separate potential webseeds
+        if tracker.is_webseed:
+            webseeds.add(tracker.uri)
+        else:
+            trackers.add(tracker.uri)
 
     # and finally our tracker list
     trackers.update(default_trackers())
 
-    return list(trackers)
+    return list(trackers), list(webseeds)
 
 
 def get_default_trackers():
@@ -103,9 +110,12 @@ def create_magnet_from_es_info():
     return dict(create_magnet_from_es_info=_create_magnet_from_es_info)
 
 
-def create_default_metadata_base(torrent, trackers=None):
-    if trackers is None:
-        trackers = get_trackers(torrent)
+def create_default_metadata_base(torrent, trackers=None, webseeds=None):
+    if trackers is None or webseeds is None:
+        db_trackers, db_webseeds = get_trackers_and_webseeds(torrent)
+
+        trackers = db_trackers if trackers is None else trackers
+        webseeds = db_webseeds if webseeds is None else webseeds
 
     metadata_base = {
         'created by': 'NyaaV2',
@@ -119,6 +129,10 @@ def create_default_metadata_base(torrent, trackers=None):
     if len(trackers) > 1:
         # Yes, it's a list of lists with a single element inside.
         metadata_base['announce-list'] = [[tracker] for tracker in trackers[:MAX_TRACKERS]]
+
+    # Add webseeds
+    if webseeds:
+        metadata_base['url-list'] = webseeds
 
     return metadata_base
 


### PR DESCRIPTION
***Note:*** contains schema changes (adds column `Trackers.is_webseed`)

Fixes #302

Adds webseed support ([BEP-19](http://www.bittorrent.org/beps/bep_0019.html)):
* Alembic migration for schema
* validating & storing webseeds on upload
* adjusts `.torrent` metadata generation
    * fetch trackers and webseeds at the same time and separate them

The `Trackers` table is used to store both announce urls and webseeds, separated by the `is_webseed` field. This way we can still use `TorrentTrackersBase` for the relations and avoid clutter.

Tested & working.