### PR TITLE
Update ES mapping with `asciifolding` filter

### DIFF
--- a/es_mapping.yml
+++ b/es_mapping.yml
@@ -12,6 +12,7 @@ settings:
         filter:
           - standard
           - lowercase
+          - asciifolding
       my_index_analyzer:
         type: custom
         tokenizer: standard


### PR DESCRIPTION
Just from reading the [docs](https://www.elastic.co/guide/en/elasticsearch/guide/current/asciifolding-token-filter.html), unable to actually test... :<
(the line at EOF was automatically added by github)

Fixes #321