### PR TITLE
Minimum size for user-less anonymous torrents (+ post-WTForms validation)

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -46,6 +46,9 @@ ENFORCE_MAIN_ANNOUNCE_URL = False
 MAIN_ANNOUNCE_URL = 'http://127.0.0.1:6881/announce'
 TRACKER_API_URL = 'http://127.0.0.1:6881/api'
 TRACKER_API_AUTH = 'topsecret'
+# Torrents uploaded without an account must be at least this big in total (bytes)
+# Set to 0 to disable
+MINIMUM_ANONYMOUS_TORRENT_SIZE = 1 * 1024 * 1024
 
 BACKUP_TORRENT_FOLDER = 'torrents'
 

--- a/nyaa/api_handler.py
+++ b/nyaa/api_handler.py
@@ -99,22 +99,25 @@ def v2_api_upload():
     upload_form.category.choices = _create_upload_category_choices()
 
     if upload_form.validate():
-        torrent = backend.handle_torrent_upload(upload_form, flask.g.user)
+        try:
+            torrent = backend.handle_torrent_upload(upload_form, flask.g.user)
 
-        # Create a response dict with relevant data
-        torrent_metadata = {
-            'url': flask.url_for('torrents.view', torrent_id=torrent.id, _external=True),
-            'id': torrent.id,
-            'name': torrent.display_name,
-            'hash': torrent.info_hash.hex(),
-            'magnet': torrent.magnet_uri
-        }
+            # Create a response dict with relevant data
+            torrent_metadata = {
+                'url': flask.url_for('torrents.view', torrent_id=torrent.id, _external=True),
+                'id': torrent.id,
+                'name': torrent.display_name,
+                'hash': torrent.info_hash.hex(),
+                'magnet': torrent.magnet_uri
+            }
 
-        return flask.jsonify(torrent_metadata)
-    else:
-        # Map errors back from form fields into the api keys
-        mapped_errors = {UPLOAD_API_FORM_KEYMAP.get(k, k): v for k, v in upload_form.errors.items()}
-        return flask.jsonify({'errors': mapped_errors}), 400
+            return flask.jsonify(torrent_metadata)
+        except backend.TorrentExtraValidationException:
+            pass
+
+    # Map errors back from form fields into the api keys
+    mapped_errors = {UPLOAD_API_FORM_KEYMAP.get(k, k): v for k, v in upload_form.errors.items()}
+    return flask.jsonify({'errors': mapped_errors}), 400
 
 
 # #################################### TEMPORARY ####################################

--- a/nyaa/views/torrents.py
+++ b/nyaa/views/torrents.py
@@ -307,13 +307,16 @@ def upload():
     upload_form.category.choices = _create_upload_category_choices()
 
     if flask.request.method == 'POST' and upload_form.validate():
-        torrent = backend.handle_torrent_upload(upload_form, flask.g.user)
+        try:
+            torrent = backend.handle_torrent_upload(upload_form, flask.g.user)
 
-        return flask.redirect(flask.url_for('torrents.view', torrent_id=torrent.id))
-    else:
-        # If we get here with a POST, it means the form data was invalid: return a non-okay status
-        status_code = 400 if flask.request.method == 'POST' else 200
-        return flask.render_template('upload.html', upload_form=upload_form), status_code
+            return flask.redirect(flask.url_for('torrents.view', torrent_id=torrent.id))
+        except backend.TorrentExtraValidationException:
+            pass
+
+    # If we get here with a POST, it means the form data was invalid: return a non-okay status
+    status_code = 400 if flask.request.method == 'POST' else 200
+    return flask.render_template('upload.html', upload_form=upload_form), status_code
 
 
 @cached_function


### PR DESCRIPTION
`MINIMUM_ANONYMOUS_TORRENT_SIZE` can be used to require a minimum total size of torrents uploaded by anonymous users (ie. without accounts) to cut down on spam.

As growing the original upload form validator too big is unreasonable, this PR also prepares for various "advanced" validations, such as blacklisting extensions per torrent category. In this post-WTForms context we have clean access to the database as well.
Torrents will be validated just before the final `session.commit()`, and any code calling `backend.handle_torrent_upload` should prepare for raised `TorrentExtraValidationException`s.

Any errors in the new validator will be added to the form, meshing nicely with the current error display:
![image](https://user-images.githubusercontent.com/6820963/29491008-39a98b44-8557-11e7-8219-ae44042ee350.png)
