### PR TITLE
Disable report button on empty reason

### DIFF
--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -200,7 +200,7 @@
 					{{ render_field(report_form.reason, class_='form-control', maxlength=255) }}
 					<div style="float: right;">
 						<button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-						<button type="submit" class="btn btn-danger">Report</button>
+						<button type="submit" id="reportSubmit" class="btn btn-danger">Report</button>
 					</div>
 				</form>
 			</div>
@@ -214,6 +214,14 @@
 	// Focus the report text field once the modal is opened.
 	$('#reportModal').on('shown.bs.modal', function () {
 		$('#reason').focus();
+		$('#reportSubmit').attr('disabled', true);
+	});
+	$('#reason').on('input', function(e) {
+		if($('#reason').val().length > 0) {
+			$('#reportSubmit').removeAttr('disabled');
+		} else {
+			$('#reportSubmit').attr('disabled', true);
+		}
 	});
 </script>
 {% endif %}

--- a/nyaa/views/torrents.py
+++ b/nyaa/views/torrents.py
@@ -376,6 +376,8 @@ def submit_report(torrent_id):
         db.session.add(report)
         db.session.commit()
         flask.flash('Successfully reported torrent!', 'success')
+    elif len(form.reason.data) == 0:
+        flask.flash('Please give a report reason!', 'danger')
 
     return flask.redirect(flask.url_for('torrents.view', torrent_id=torrent_id))
 


### PR DESCRIPTION
Previously, people couldn't quite tell you needed to give a report reason. Now we disable the submit button until there is a reason, and flask.flash() if someone manages to submit an empty reason anyway.