### PR TITLE
Implement torrent nuking ability for mods

### DIFF
--- a/nyaa/backend.py
+++ b/nyaa/backend.py
@@ -292,7 +292,7 @@ def tracker_api(info_hashes, method):
     # Split list into at most 100 elements
     chunk_size = 100
     chunk_range = range(0, len(info_hashes), chunk_size)
-    chunked_info_hashes = (info_hashes[i:i+chunk_size] for i in chunk_range)
+    chunked_info_hashes = (info_hashes[i:i + chunk_size] for i in chunk_range)
 
     for info_hashes_chunk in chunked_info_hashes:
         qs = [

--- a/nyaa/forms.py
+++ b/nyaa/forms.py
@@ -225,6 +225,7 @@ class DeleteForm(FlaskForm):
 class BanForm(FlaskForm):
     ban_user = SubmitField("Delete & Ban and Ban User")
     ban_userip = SubmitField("Delete & Ban and Ban User+IP")
+    nuke = SubmitField("Delete & Ban all torrents")
     unban = SubmitField("Unban")
 
     _validator = DataRequired()

--- a/nyaa/templates/user.html
+++ b/nyaa/templates/user.html
@@ -55,47 +55,66 @@
 				</div>
 				<div class="panel-body">
 					<form method="POST">
-						{{ ban_form.csrf_token }}
-						{% if user.is_banned %}
-						This user is <strong>banned</strong>.<br>
-						{% endif %}
-						{% if ipbanned %}
-						This user is <strong>ip banned</strong>.<br>
-						{% endif %}
-						{% if not user.is_banned and not bans %}
-						This user is <strong>not banned</strong>.<br>
-						{% endif %}
-						<br>
+						<div class="row">
+							<div class="col-md-12">
+								{{ ban_form.csrf_token }}
+								{% if user.is_banned %}
+								This user is <strong>banned</strong>.
+								{% endif %}
+								{% if ipbanned %}
+								This user is <strong>ip banned</strong>.
+								{% endif %}
+								{% if not user.is_banned and not bans %}
+								This user is <strong>not banned</strong>.
+								{% endif %}
+							</div>
+						</div>
 						{% if user.is_banned or bans %}
-						<p>
-							{% for ban in bans %}
-							#{{ ban.id }}
-							by <a href="{{ url_for('users.view_user', user_name=ban.admin.username) }}">{{ ban.admin.username }}</a>
-							for <span markdown-text-inline>{{ ban.reason }}</span>
-							<br>
-							{% endfor %}
-						</p>
-						{{ ban_form.unban(class="btn btn-info") }}
+						<div class="row">
+							<div class="col-md-12">
+								<p>
+									{% for ban in bans %}
+									#{{ ban.id }}
+									by <a href="{{ url_for('users.view_user', user_name=ban.admin.username) }}">{{ ban.admin.username }}</a>
+									for <span markdown-text-inline>{{ ban.reason }}</span>
+									{% endfor %}
+								</p>
+							</div>
+						</div>
+						<div class="row">
+							<div class="col-md-12">
+								{{ ban_form.unban(class="btn btn-info") }}
+							</div>
+						</div>
 						{% endif %}
 
 						{% if not user.is_banned or not ipbanned %}
 						{% if user.is_banned or bans %}
 						<hr>
 						{% endif %}
-						{{ render_field(ban_form.reason, class_="form-control", placeholder="Specify a ban reason.") }}<br>
-						<div class="pull-left">
-							{% if not user.is_banned %}
-							{{ ban_form.ban_user(value="Ban User", class="btn btn-danger") }}
-							{% else %}
-							<button type="button" class="btn btn-danger disabled">Already banned</button>
-							{% endif %}
+						<div class="row" style="margin-top:1.5em">
+							<div class="col-md-12">
+								{{ render_field(ban_form.reason, class_="form-control", placeholder="Specify a ban reason.") }}<br>
+							</div>
 						</div>
-						<div class="pull-right">
-							{% if not ipbanned %}
-							{{ ban_form.ban_userip(value="Ban User+IP", class="btn btn-danger") }}
-							{% else %}
-							<button type="button" class="btn btn-danger disabled">Already IP banned</button>
-							{% endif %}
+						<div class="row">
+							<div class="col-md-4 text-left">
+								{% if not user.is_banned %}
+								{{ ban_form.ban_user(value="Ban User", class="btn btn-danger") }}
+								{% else %}
+								<button type="button" class="btn btn-danger disabled">Already banned</button>
+								{% endif %}
+							</div>
+							<div class="col-md-4 text-center">
+								{% if not ipbanned %}
+								{{ ban_form.ban_userip(value="Ban User+IP", class="btn btn-danger") }}
+								{% else %}
+								<button type="button" class="btn btn-danger disabled">Already IP banned</button>
+								{% endif %}
+							</div>
+							<div class="col-md-4 text-right">
+								{{ ban_form.nuke(value="\U0001F4A3 Nuke Torrents", class="btn btn-danger") }}
+							</div>
 						</div>
 						{% endif %}
 					</form>
@@ -106,10 +125,12 @@
 	</div>
 {% endif %}
 
-<h3>
-	Browsing <span class="text-{{ user.userlevel_color }}" data-toggle="tooltip" title="{{ user.userlevel_str }}">{{ user.username }}</span>'{{ '' if user.username[-1] == 's' else 's' }} torrents
-</h3>
+<div class="row">
+	<h3>
+		Browsing <span class="text-{{ user.userlevel_color }}" data-toggle="tooltip" title="{{ user.userlevel_str }}">{{ user.username }}</span>'{{ '' if user.username[-1] == 's' else 's' }} torrents
+	</h3>
 
 {% include "search_results.html" %}
 
 {% endblock %}
+</div>

--- a/nyaa/templates/user.html
+++ b/nyaa/templates/user.html
@@ -113,7 +113,11 @@
 								{% endif %}
 							</div>
 							<div class="col-md-4 text-right">
+								{% if g.user.is_superadmin %}
 								{{ ban_form.nuke(value="\U0001F4A3 Nuke Torrents", class="btn btn-danger") }}
+								{% else %}
+								<button type="button" class="btn btn-danger disabled">&#x1f4a3; Nuke Torrents</button>
+								{% endif %}
 							</div>
 						</div>
 						{% endif %}

--- a/nyaa/views/users.py
+++ b/nyaa/views/users.py
@@ -1,10 +1,10 @@
 import math
 from ipaddress import ip_address
+from itertools import chain
 
 import flask
 from flask_paginate import Pagination
 
-from itertools import chain
 from itsdangerous import BadSignature, URLSafeSerializer
 
 from nyaa import backend, forms, models

--- a/nyaa/views/users.py
+++ b/nyaa/views/users.py
@@ -4,6 +4,7 @@ from ipaddress import ip_address
 import flask
 from flask_paginate import Pagination
 
+from itertools import chain
 from itsdangerous import BadSignature, URLSafeSerializer
 
 from nyaa import backend, forms, models
@@ -11,7 +12,6 @@ from nyaa.extensions import db
 from nyaa.search import (DEFAULT_MAX_SEARCH_RESULT, DEFAULT_PER_PAGE, SERACH_PAGINATE_DISPLAY_MSG,
                          _generate_query_string, search_db, search_elastic)
 from nyaa.utils import chain_get
-from itertools import chain
 
 app = flask.current_app
 bp = flask.Blueprint('users', __name__)
@@ -102,17 +102,26 @@ def view_user(user_name):
         return flask.redirect(url)
 
     if flask.request.method == 'POST' and ban_form and ban_form.nuke.data:
-        num_banned = 0
+        nyaa_banned = 0
+        sukebei_banned = 0
         for t in chain(user.nyaa_torrents, user.sukebei_torrents):
             t.deleted = True
             t.banned = True
             backend.tracker_api([t.info_hash], 'ban')
             db.session.add(t)
-            num_banned += 1
+            if isinstance(t, models.NyaaTorrent):
+                nyaa_banned += 1
+            else:
+                sukebei_banned += 1
 
-        log = "Nuked {0} torrents of {1}".format(num_banned, user.username)
-        adminlog = models.AdminLog(log=log, admin_id=flask.g.user.id)
-        db.session.add(adminlog)
+        for log_flavour, num in ((models.NyaaAdminLog, nyaa_banned),
+                                 (models.SukebeiAdminLog, sukebei_banned)):
+            if num > 0:
+                log = "Nuked {0} torrents of [{1}]({2})".format(num,
+                                                                user.username,
+                                                                url)
+                adminlog = log_flavour(log=log, admin_id=flask.g.user.id)
+                db.session.add(adminlog)
         db.session.commit()
         flask.flash('Torrents of {0} have been nuked.'.format(user.username),
                     'success')


### PR DESCRIPTION
This deletes and bans all torrents of a specific user.

A current caveat is that it will delete both sukebei and nyaa torrents, but will only leave a log entry in the current flavour's log.

Also did some bootstrap untangling on the user view page.

Please review these changes carefully, it's my first time messing with the DB, and I did not check whether it sends the ban command to the tracker properly.

Also, we may want to restrict nuking to only supermods.