### PR TITLE
[Config change] Password reset by email

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -40,6 +40,10 @@ USE_MYSQL = True
 # Show seeds/peers/completions in torrent list/page
 ENABLE_SHOW_STATS = True
 
+# Enable password recovery (by reset link to given email address)
+# Depends on email support!
+ALLOW_PASSWORD_RESET = True
+
 # Recaptcha keys (https://www.google.com/recaptcha)
 RECAPTCHA_PUBLIC_KEY = '***'
 RECAPTCHA_PRIVATE_KEY = '***'

--- a/nyaa/email.py
+++ b/nyaa/email.py
@@ -12,6 +12,7 @@ from nyaa import models
 class EmailHolder(object):
     ''' Holds email subject, recipient and content, so we have a general class for
         all mail backends. '''
+
     def __init__(self, subject=None, recipient=None, text=None, html=None):
         self.subject = subject
         self.recipient = recipient  # models.User or string

--- a/nyaa/templates/email/reset-request.html
+++ b/nyaa/templates/email/reset-request.html
@@ -1,0 +1,24 @@
+<html>
+	<head>
+		<title>{{ config.GLOBAL_SITE_NAME }} password reset request</title>
+		<style type="text/css">
+		.well {
+			display: inline-block;
+			border-radius: 5px;
+			padding: 10px;
+			background-color: rgb(240, 240, 240)
+		}
+		</style>
+	</head>
+	<body>
+		<div>
+			{{ user.username }}, you've requested to reset your password on {{ config.GLOBAL_SITE_NAME }}. Click the link below to change your password:
+		</div>
+		<div class="well">
+			<a href="{{ reset_link }}">{{ reset_link }}</a>
+		</div>
+		<div>
+			If you did not request a password reset, you may ignore this email.
+		</div>
+	</body>
+</html>

--- a/nyaa/templates/email/reset-request.txt
+++ b/nyaa/templates/email/reset-request.txt
@@ -1,0 +1,5 @@
+{{ user.username }}, you've requested to reset your password on {{ config.GLOBAL_SITE_NAME }}. Open the link below to change your password:
+
+{{ reset_link }}
+
+If you did not request a password reset, you may ignore this email.

--- a/nyaa/templates/email/reset.html
+++ b/nyaa/templates/email/reset.html
@@ -1,0 +1,10 @@
+<html>
+	<head>
+		<title>Your {{ config.GLOBAL_SITE_NAME }} password has been reset</title>
+	</head>
+	<body>
+		<div>
+			{{ user.username }}, your password on {{ config.GLOBAL_SITE_NAME }} has just been successfully reset from a password-reset link.
+		</div>
+	</body>
+</html>

--- a/nyaa/templates/email/reset.txt
+++ b/nyaa/templates/email/reset.txt
@@ -1,0 +1,1 @@
+{{ user.username }}, your password on {{ config.GLOBAL_SITE_NAME }} has just been successfully reset from a password-reset link.

--- a/nyaa/templates/login.html
+++ b/nyaa/templates/login.html
@@ -18,7 +18,37 @@
 
 		<div class="row">
 			<div class="form-group col-md-4">
-				{{ render_field(form.password, class_='form-control', placeholder='Password') }}
+				{# This is just render_field() exploded so that we can add the password link after the label #}
+				{% if form.password.errors %}
+					<div class="form-group has-error">
+				{% else %}
+					<div class="form-group">
+				{% endif %}
+						{{ form.password.label(class='control-label') }}
+
+						{% if config.ALLOW_PASSWORD_RESET: %}
+						<small>
+							<a href="{{ url_for('account.password_reset') }}">Forgot your password?</a>
+						</small>
+						{% endif%}
+
+						{{ form.password(title=form.password.description, class_='form-control') | safe }}
+						{% if form.password.errors %}
+							<div class="help-block">
+								{% if form.password.errors|length < 2 %}
+									{% for error in form.password.errors %}
+										{{ error }}
+									{% endfor %}
+								{% else %}
+									<ul>
+										{% for error in form.password.errors %}
+											<li>{{ error }}</li>
+										{% endfor %}
+									</ul>
+								{% endif %}
+							</div>
+						{% endif %}
+					</div>
 			</div>
 		</div>
 

--- a/nyaa/templates/password_reset.html
+++ b/nyaa/templates/password_reset.html
@@ -1,0 +1,31 @@
+{% extends "layout.html" %}
+{% block title %}Password reset :: {{ config.SITE_NAME }}{% endblock %}
+{% block metatags %}
+<meta property="og:description" content="Reset your password on {{ config.SITE_NAME }}!">
+{% endblock %}
+{% block body %}
+{% from "_formhelpers.html" import render_field %}
+
+<h1>Password reset</h1>
+	<form method="POST">
+		{{ form.csrf_token }}
+
+		<div class="row">
+			<div class="form-group col-md-4">
+				{{ render_field(form.password, class_='form-control', placeholder='Password') }}
+			</div>
+		</div>
+
+		<div class="row">
+			<div class="form-group col-md-4">
+				{{ render_field(form.password_confirm, class_='form-control', placeholder='Password (confirm)') }}
+			</div>
+		</div>
+
+		<div class="row">
+			<div class="col-md-4">
+				<input type="submit" value="Reset password" class="btn btn-primary">
+			</div>
+		</div>
+	</form>
+{% endblock %}

--- a/nyaa/templates/password_reset_request.html
+++ b/nyaa/templates/password_reset_request.html
@@ -1,0 +1,38 @@
+{% extends "layout.html" %}
+{% block title %}Password reset request :: {{ config.SITE_NAME }}{% endblock %}
+{% block metatags %}
+<meta property="og:description" content="Request to reset your password on {{ config.SITE_NAME }}!">
+{% endblock %}
+{% block body %}
+{% from "_formhelpers.html" import render_field %}
+
+<h1>Request password reset</h1>
+	<form method="POST">
+		{{ form.csrf_token }}
+
+		<div class="row">
+			<div class="form-group col-md-4">
+				{{ render_field(form.email, class_='form-control', placeholder='Email address') }}
+			</div>
+		</div>
+
+		{% if config.USE_RECAPTCHA %}
+		<div class="row">
+			<div class="col-md-4">
+				{% for error in form.recaptcha.errors %}
+				{{ error }}
+				{% endfor %}
+				{{ form.recaptcha }}
+			</div>
+		</div>
+		<br>
+
+		{% endif %}
+
+		<div class="row">
+			<div class="col-md-4">
+				<input type="submit" value="Request password reset" class="btn btn-primary">
+			</div>
+		</div>
+	</form>
+{% endblock %}

--- a/nyaa/views/account.py
+++ b/nyaa/views/account.py
@@ -1,4 +1,5 @@
 import binascii
+import time
 from datetime import datetime
 from ipaddress import ip_address
 
@@ -122,12 +123,16 @@ def password_reset(payload=None):
     else:
         s = get_serializer()
         try:
-            pw_hash, user_id = s.loads(payload)
+            request_timestamp, pw_hash, user_id = s.loads(payload)
         except:
             return flask.abort(404)
 
         user = models.User.by_id(user_id)
         if not user:
+            return flask.abort(404)
+
+        # Timeout after six hours
+        if (time.time() - request_timestamp) > 6 * 3600:
             return flask.abort(404)
 
         sha1_password_hash_hash = binascii.hexlify(sha1_hash(user.password_hash.hash)).decode()

--- a/nyaa/views/users.py
+++ b/nyaa/views/users.py
@@ -1,3 +1,4 @@
+import binascii
 import math
 from ipaddress import ip_address
 
@@ -10,7 +11,7 @@ from nyaa import forms, models
 from nyaa.extensions import db
 from nyaa.search import (DEFAULT_MAX_SEARCH_RESULT, DEFAULT_PER_PAGE, SERACH_PAGINATE_DISPLAY_MSG,
                          _generate_query_string, search_db, search_elastic)
-from nyaa.utils import chain_get
+from nyaa.utils import chain_get, sha1_hash
 
 app = flask.current_app
 bp = flask.Blueprint('users', __name__)
@@ -251,3 +252,13 @@ def get_activation_link(user):
     s = get_serializer()
     payload = s.dumps(user.id)
     return flask.url_for('users.activate_user', payload=payload, _external=True)
+
+
+def get_password_reset_link(user):
+    # This mess to not to have static password reset links
+    # Maybe not the best idea? But this should not be a security risk, and it works.
+    password_hash_hash = binascii.hexlify(sha1_hash(user.password_hash.hash)).decode()
+
+    s = get_serializer()
+    payload = s.dumps((password_hash_hash, user.id))
+    return flask.url_for('account.password_reset', payload=payload, _external=True)

--- a/nyaa/views/users.py
+++ b/nyaa/views/users.py
@@ -1,5 +1,6 @@
 import binascii
 import math
+import time
 from ipaddress import ip_address
 
 import flask
@@ -260,5 +261,5 @@ def get_password_reset_link(user):
     password_hash_hash = binascii.hexlify(sha1_hash(user.password_hash.hash)).decode()
 
     s = get_serializer()
-    payload = s.dumps((password_hash_hash, user.id))
+    payload = s.dumps((time.time(), password_hash_hash, user.id))
     return flask.url_for('account.password_reset', payload=payload, _external=True)


### PR DESCRIPTION
**Depends on #380!** See the changes of this PR alone [here](https://github.com/nyaadevs/nyaa/compare/email...password-reset)

Closes #44 

Adds password recovery by email, includes a link on login page, etc.

Adds a new `config.py` entry: `ALLOW_PASSWORD_RESET`

----

![image](https://user-images.githubusercontent.com/6820963/31311194-cc3ad5ca-abaf-11e7-87dd-0bcdc717e02a.png)
*Link on login page*

![image](https://user-images.githubusercontent.com/6820963/31311195-d166559c-abaf-11e7-897f-558fc545cf81.png)
*Reset request form*

![image](https://user-images.githubusercontent.com/6820963/31311211-0659d940-abb0-11e7-8d29-977b4f5dfe16.png)
*Flash*

![image](https://user-images.githubusercontent.com/6820963/31311206-fdf134ba-abaf-11e7-8a69-ecc3392e94ab.png)
*Sent email*

![image](https://user-images.githubusercontent.com/6820963/31311215-0e4a3096-abb0-11e7-8255-fb6003f3844b.png)
*Reset form*

![image](https://user-images.githubusercontent.com/6820963/31311222-37cae366-abb0-11e7-8112-dace2198a3a0.png)
*After reset*

![image](https://user-images.githubusercontent.com/6820963/31311226-47f1b2e2-abb0-11e7-9419-80d2ca984390.png)
*Reset notification email*