### PR TITLE
Add pagination on the top of search results

### DIFF
--- a/nyaa/templates/search_results.html
+++ b/nyaa/templates/search_results.html
@@ -27,9 +27,6 @@
 	{{ render_pagination(torrent_query) }}
 	{% endif %}
 </div>
-{% endif %}
-
-{% if (use_elastic and torrent_query.hits.total > 0) or (torrent_query.items) %}
 <div class="table-responsive">
 	<table class="table table-bordered table-hover table-striped torrent-list">
 		<thead>

--- a/nyaa/templates/search_results.html
+++ b/nyaa/templates/search_results.html
@@ -18,6 +18,18 @@
 {% endif %}
 
 {% if (use_elastic and torrent_query.hits.total > 0) or (torrent_query.items) %}
+<div class="center">
+	{% if use_elastic %}
+	{{ pagination.info }}
+	{{ pagination.links }}
+	{% else %}
+	{% from "bootstrap/pagination.html" import render_pagination %}
+	{{ render_pagination(torrent_query) }}
+	{% endif %}
+</div>
+{% endif %}
+
+{% if (use_elastic and torrent_query.hits.total > 0) or (torrent_query.items) %}
 <div class="table-responsive">
 	<table class="table table-bordered table-hover table-striped torrent-list">
 		<thead>


### PR DESCRIPTION
Added additional pagination on the top of the search results as mentioned in issue #364. Untested, but should work. Doesn't show if there's 0 results to avoid doubling the "Displaying results 0-0 out of 0 results.".