### PR TITLE
Fix nuke button visbility

### DIFF
--- a/nyaa/forms.py
+++ b/nyaa/forms.py
@@ -265,7 +265,6 @@ class DeleteForm(FlaskForm):
 class BanForm(FlaskForm):
     ban_user = SubmitField("Delete & Ban and Ban User")
     ban_userip = SubmitField("Delete & Ban and Ban User+IP")
-    nuke = SubmitField("Delete & Ban all torrents")
     unban = SubmitField("Unban")
 
     _validator = DataRequired()
@@ -278,6 +277,10 @@ class BanForm(FlaskForm):
         _validate_reason,
         Length(max=1024, message='Reason must be at most %(max)d characters long.')
     ])
+
+
+class NukeForm(FlaskForm):
+    nuke_torrents = SubmitField("\U0001F4A3 Nuke Torrents")
 
 
 class UploadForm(FlaskForm):

--- a/nyaa/templates/user.html
+++ b/nyaa/templates/user.html
@@ -98,26 +98,27 @@
 							</div>
 						</div>
 						<div class="row">
-							<div class="col-md-4 text-left">
+							<div class="col-md-6 text-left">
 								{% if not user.is_banned %}
 								{{ ban_form.ban_user(value="Ban User", class="btn btn-danger") }}
 								{% else %}
 								<button type="button" class="btn btn-danger disabled">Already banned</button>
 								{% endif %}
 							</div>
-							<div class="col-md-4 text-center">
+							<div class="col-md-6 text-right">
 								{% if not ipbanned %}
 								{{ ban_form.ban_userip(value="Ban User+IP", class="btn btn-danger") }}
 								{% else %}
 								<button type="button" class="btn btn-danger disabled">Already IP banned</button>
 								{% endif %}
 							</div>
-							<div class="col-md-4 text-right">
-								{% if g.user.is_superadmin %}
+						</div>
+						{% endif %}
+						{% if g.user.is_superadmin %}
+						<hr>
+						<div class="row">
+							<div class="col-md-6 text-left">
 								{{ ban_form.nuke(value="\U0001F4A3 Nuke Torrents", class="btn btn-danger") }}
-								{% else %}
-								<button type="button" class="btn btn-danger disabled">&#x1f4a3; Nuke Torrents</button>
-								{% endif %}
 							</div>
 						</div>
 						{% endif %}

--- a/nyaa/templates/user.html
+++ b/nyaa/templates/user.html
@@ -114,15 +114,18 @@
 							</div>
 						</div>
 						{% endif %}
-						{% if g.user.is_superadmin %}
-						<hr>
+					</form>
+					{% if g.user.is_superadmin %}
+					<hr>
+					<form method="POST" onsubmit="return prompt('Please type {{ user.username }} to confirm').toLowerCase() == '{{ user.username }}'.toLowerCase()">
+						{{ nuke_form.csrf_token }}
 						<div class="row">
 							<div class="col-md-6 text-left">
-								{{ ban_form.nuke(value="\U0001F4A3 Nuke Torrents", class="btn btn-danger") }}
+								{{ nuke_form.nuke_torrents(class="btn btn-danger", formaction=url_for('users.nuke_user_torrents', user_name=user.username)) }}
 							</div>
 						</div>
-						{% endif %}
 					</form>
+					{% endif %}
 				</div>
 			</div>
 		</div>

--- a/nyaa/utils.py
+++ b/nyaa/utils.py
@@ -4,6 +4,8 @@ import random
 import string
 from collections import OrderedDict
 
+import flask
+
 
 def sha1_hash(input_bytes):
     """ Hash given bytes with hashlib.sha1 and return the digest (as bytes) """
@@ -78,3 +80,13 @@ def chain_get(source, *args):
         if value is not sentinel:
             return value
     return None
+
+
+def admin_only(f):
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        if flask.g.user and flask.g.user.is_superadmin:
+            return f(*args, **kwargs)
+        else:
+            flask.abort(401)
+    return wrapper

--- a/nyaa/views/users.py
+++ b/nyaa/views/users.py
@@ -13,7 +13,7 @@ from nyaa import backend, forms, models
 from nyaa.extensions import db
 from nyaa.search import (DEFAULT_MAX_SEARCH_RESULT, DEFAULT_PER_PAGE, SERACH_PAGINATE_DISPLAY_MSG,
                          _generate_query_string, search_db, search_elastic)
-from nyaa.utils import chain_get, sha1_hash
+from nyaa.utils import admin_only, chain_get, sha1_hash
 
 app = flask.current_app
 bp = flask.Blueprint('users', __name__)
@@ -30,6 +30,7 @@ def view_user(user_name):
     ban_form = None
     bans = None
     ipbanned = None
+    nuke_form = None
     if flask.g.user and flask.g.user.is_moderator and flask.g.user.level > user.level:
         admin_form = forms.UserForm()
         default, admin_form.user_class.choices = _create_user_class_choices(user)
@@ -37,6 +38,7 @@ def view_user(user_name):
             admin_form.user_class.data = default
 
         ban_form = forms.BanForm()
+        nuke_form = forms.NukeForm()
         if flask.request.method == 'POST':
             doban = (ban_form.ban_user.data or ban_form.unban.data or ban_form.ban_userip.data)
         bans = models.Ban.banned(user.id, user.last_login_ip).all()
@@ -102,41 +104,6 @@ def view_user(user_name):
 
         flask.flash(flask.Markup('User has been successfully {0}.'.format(action)), 'success')
         return flask.redirect(url)
-
-    if flask.request.method == 'POST' and ban_form and ban_form.nuke.data:
-        if flask.g.user.is_superadmin:
-            nyaa_banned = 0
-            sukebei_banned = 0
-            info_hashes = []
-            for t in chain(user.nyaa_torrents, user.sukebei_torrents):
-                t.deleted = True
-                t.banned = True
-                info_hashes.append([t.info_hash])
-                db.session.add(t)
-                if isinstance(t, models.NyaaTorrent):
-                    nyaa_banned += 1
-                else:
-                    sukebei_banned += 1
-
-            if info_hashes:
-                backend.tracker_api(info_hashes, 'ban')
-
-            for log_flavour, num in ((models.NyaaAdminLog, nyaa_banned),
-                                     (models.SukebeiAdminLog, sukebei_banned)):
-                if num > 0:
-                    log = "Nuked {0} torrents of [{1}]({2})".format(num,
-                                                                    user.username,
-                                                                    url)
-                    adminlog = log_flavour(log=log, admin_id=flask.g.user.id)
-                    db.session.add(adminlog)
-
-            db.session.commit()
-            flask.flash('Torrents of {0} have been nuked.'.format(user.username),
-                        'success')
-            return flask.redirect(url)
-        else:
-            flask.flash('Insufficient permissions to nuke.', 'danger')
-            return flask.redirect(url)
 
     req_args = flask.request.args
 
@@ -222,6 +189,7 @@ def view_user(user_name):
                                      rss_filter=rss_query_string,
                                      admin_form=admin_form,
                                      ban_form=ban_form,
+                                     nuke_form=nuke_form,
                                      bans=bans,
                                      ipbanned=ipbanned)
 
@@ -257,6 +225,49 @@ def activate_user(payload):
 
     flask.flash(flask.Markup("You've successfully verified your account!"), 'success')
     return flask.redirect(flask.url_for('main.home'))
+
+
+@bp.route('/user/<user_name>/nuke/torrents', methods=['POST'])
+@admin_only
+def nuke_user_torrents(user_name):
+    user = models.User.by_username(user_name)
+
+    if not user:
+        flask.abort(404)
+
+    nuke_form = forms.NukeForm(flask.request.form)
+    if not nuke_form.validate():
+        flask.abort(401)
+    url = flask.url_for('users.view_user', user_name=user.username)
+    nyaa_banned = 0
+    sukebei_banned = 0
+    info_hashes = []
+    for t in chain(user.nyaa_torrents, user.sukebei_torrents):
+        t.deleted = True
+        t.banned = True
+        info_hashes.append([t.info_hash])
+        db.session.add(t)
+        if isinstance(t, models.NyaaTorrent):
+            nyaa_banned += 1
+        else:
+            sukebei_banned += 1
+
+    if info_hashes:
+        backend.tracker_api(info_hashes, 'ban')
+
+    for log_flavour, num in ((models.NyaaAdminLog, nyaa_banned),
+                             (models.SukebeiAdminLog, sukebei_banned)):
+        if num > 0:
+            log = "Nuked {0} torrents of [{1}]({2})".format(num,
+                                                            user.username,
+                                                            url)
+            adminlog = log_flavour(log=log, admin_id=flask.g.user.id)
+            db.session.add(adminlog)
+
+    db.session.commit()
+    flask.flash('Torrents of {0} have been nuked.'.format(user.username),
+                'success')
+    return flask.redirect(url)
 
 
 def _create_user_class_choices(user):


### PR DESCRIPTION
Only show it to admins, move it to its own line, and show it when users are banned.

I'll add a confirmation to the nuke button once I get around to refactoring it into its own form with its own `POST` end-point.

It's moved to its own line in preparation for future buttons like "nuke all comments". 