### PR TITLE
comments: fix small lack of validation

### DIFF
--- a/nyaa/views/torrents.py
+++ b/nyaa/views/torrents.py
@@ -342,6 +342,9 @@ def delete_comment(torrent_id, comment_id):
     if not (comment.user.id == flask.g.user.id or flask.g.user.is_moderator):
         flask.abort(403)
 
+    if torrent_id != comment.torrent_id:
+        flask.abort(400)
+
     db.session.delete(comment)
     db.session.flush()
     torrent.update_comment_count()


### PR DESCRIPTION
People could delete their own comments on torrents other than the one the URL would indicate, which meant they could mess with the total comment count on a torrent by having it be higher than it actually is through repeatedly posting and deleting comments that way.

However, they could only ever delete their own comments, so this isn't a huge issue in the first place.