### PR TITLE
Fix keyError from pop

### DIFF
--- a/nyaa/template_utils.py
+++ b/nyaa/template_utils.py
@@ -66,7 +66,7 @@ def static_cachebuster(filename):
 def modify_query(**new_values):
     args = flask.request.args.copy()
 
-    args.pop('p')
+    args.pop('p', None)
 
     for key, value in new_values.items():
         args[key] = value


### PR DESCRIPTION
sloppy coding on #406 
seems like pop will throw an exception if the key is not there unless we pass a default value