### PR TITLE
Improve and tidy up email blacklist regexes (Hotmail)

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -52,8 +52,11 @@ ALLOW_PASSWORD_RESET = True
 EMAIL_BLACKLIST = (
     # Hotmail completely rejects "untrusted" emails,
     # so it's less of a headache to blacklist them as users can't receive the mails anyway.
-    re.compile(r'(?i)@((hotmail|live|msn|outlook|passport)\.com|passport\.net)'),
-    re.compile(r'(?i)@outlook\.(at|be|cl|co\.(id|il|nz|th)|com\.(ar|au|br|gr|pe|tr|vn)|cz|de|dk|es|fr|hu|ie|in|it|jp|kr|lv|my|ph|pt|sa|sg|sk)'),
+    # (Hopefully) complete list of Microsoft email domains follows:
+    re.compile(r'(?i)@hotmail\.(co|co\.uk|com|de|dk|eu|fr|it|net|org|se)'),
+    re.compile(r'(?i)@live\.(co|co.uk|com|de|dk|eu|fr|it|net|org|se)'),
+    re.compile(r'(?i)@outlook\.(at|be|cl|co|co\.(id|il|nz|th)|com|com\.(ar|au|au|br|gr|pe|tr|vn)|cz|de|de|dk|dk|es|eu|fr|fr|hu|ie|in|it|it|jp|kr|lv|my|org|ph|pt|sa|se|sg|sk)'),
+    re.compile(r'(?i)@(msn\.com|passport\.(com|net))'),
     # '@dodgydomain.tk'
 )
 

--- a/nyaa/templates/register.html
+++ b/nyaa/templates/register.html
@@ -7,7 +7,7 @@
 {% from "_formhelpers.html" import render_field %}
 
 <h1>Register</h1>
-	<p><strong>Important:</strong> Do not use Outlook (Hotmail) email addresses, they discard our verification email without sending it to spam. No support is offered if you ignore this warning.</p>
+	<p><strong>Important:</strong> Do not use Outlook (Hotmail/Live/MSN) email addresses, they discard our verification email without sending it to spam. No support is offered if you ignore this warning.</p>
 	<form method="POST">
 		{{ form.csrf_token }}
 


### PR DESCRIPTION
Because reading warnings is overrated.
This does not fix people using custom domains, but it's more likely they'll know what's up when their email is thrown into the void.

Fixes #437.