### PR TITLE
Implement comment locking

### DIFF
--- a/nyaa/backend.py
+++ b/nyaa/backend.py
@@ -220,7 +220,7 @@ def handle_torrent_upload(upload_form, uploading_user=None, fromAPI=False):
 
     # Only allow mods to upload locked torrents
     can_mark_locked = uploading_user and uploading_user.is_moderator
-    torrent.locked = upload_form.is_locked.data if can_mark_locked else False
+    torrent.comment_locked = upload_form.is_comment_locked.data if can_mark_locked else False
 
     # Set category ids
     torrent.main_category_id, torrent.sub_category_id = \

--- a/nyaa/backend.py
+++ b/nyaa/backend.py
@@ -218,6 +218,10 @@ def handle_torrent_upload(upload_form, uploading_user=None, fromAPI=False):
     # To do, automatically mark trusted if user is trusted unless user specifies otherwise
     torrent.trusted = upload_form.is_trusted.data if can_mark_trusted else False
 
+    # Only allow mods to upload locked torrents
+    can_mark_locked = uploading_user and uploading_user.is_moderator
+    torrent.locked = upload_form.is_locked.data if can_mark_locked else False
+
     # Set category ids
     torrent.main_category_id, torrent.sub_category_id = \
         upload_form.category.parsed_data.get_category_ids()

--- a/nyaa/forms.py
+++ b/nyaa/forms.py
@@ -263,6 +263,7 @@ class EditForm(FlaskForm):
     is_anonymous = BooleanField('Anonymous')
     is_complete = BooleanField('Complete')
     is_trusted = BooleanField('Trusted')
+    is_locked = BooleanField('Locked')
 
     information = StringField('Information', [
         Length(max=255, message='Information must be at most %(max)d characters long.')
@@ -335,6 +336,7 @@ class UploadForm(FlaskForm):
     is_anonymous = BooleanField('Anonymous')
     is_complete = BooleanField('Complete')
     is_trusted = BooleanField('Trusted')
+    is_locked = BooleanField('Locked')
 
     information = StringField('Information', [
         Length(max=255, message='Information must be at most %(max)d characters long.')

--- a/nyaa/forms.py
+++ b/nyaa/forms.py
@@ -263,7 +263,7 @@ class EditForm(FlaskForm):
     is_anonymous = BooleanField('Anonymous')
     is_complete = BooleanField('Complete')
     is_trusted = BooleanField('Trusted')
-    is_locked = BooleanField('Locked')
+    is_comment_locked = BooleanField('Lock Comments')
 
     information = StringField('Information', [
         Length(max=255, message='Information must be at most %(max)d characters long.')
@@ -336,7 +336,7 @@ class UploadForm(FlaskForm):
     is_anonymous = BooleanField('Anonymous')
     is_complete = BooleanField('Complete')
     is_trusted = BooleanField('Trusted')
-    is_locked = BooleanField('Locked')
+    is_comment_locked = BooleanField('Lock Comments')
 
     information = StringField('Information', [
         Length(max=255, message='Information must be at most %(max)d characters long.')

--- a/nyaa/models.py
+++ b/nyaa/models.py
@@ -100,7 +100,7 @@ class TorrentFlags(IntEnum):
     COMPLETE = 16
     DELETED = 32
     BANNED = 64
-    LOCKED = 128
+    COMMENT_LOCKED = 128
 
 
 class TorrentBase(DeclarativeHelperBase):
@@ -259,7 +259,7 @@ class TorrentBase(DeclarativeHelperBase):
     trusted = FlagProperty(TorrentFlags.TRUSTED)
     remake = FlagProperty(TorrentFlags.REMAKE)
     complete = FlagProperty(TorrentFlags.COMPLETE)
-    locked = FlagProperty(TorrentFlags.LOCKED)
+    comment_locked = FlagProperty(TorrentFlags.COMMENT_LOCKED)
 
     # Class methods
 

--- a/nyaa/models.py
+++ b/nyaa/models.py
@@ -100,6 +100,7 @@ class TorrentFlags(IntEnum):
     COMPLETE = 16
     DELETED = 32
     BANNED = 64
+    LOCKED = 128
 
 
 class TorrentBase(DeclarativeHelperBase):
@@ -258,6 +259,7 @@ class TorrentBase(DeclarativeHelperBase):
     trusted = FlagProperty(TorrentFlags.TRUSTED)
     remake = FlagProperty(TorrentFlags.REMAKE)
     complete = FlagProperty(TorrentFlags.COMPLETE)
+    locked = FlagProperty(TorrentFlags.LOCKED)
 
     # Class methods
 

--- a/nyaa/templates/edit.html
+++ b/nyaa/templates/edit.html
@@ -68,6 +68,14 @@
 					Trusted
 				</label>
 				{% endif %}
+				{% if g.user.is_moderator %}
+				<label class="btn btn-default {% if torrent.locked %}active{% endif %}" title="Lock commenting">
+					{{ form.is_locked }}
+					<span class="glyphicon glyphicon-check"></span>
+					<span class="glyphicon glyphicon-unchecked"></span>
+					Locked
+				</label>
+				{% endif %}
 			</div>
 		</div>
 	</div>

--- a/nyaa/templates/edit.html
+++ b/nyaa/templates/edit.html
@@ -69,11 +69,11 @@
 				</label>
 				{% endif %}
 				{% if g.user.is_moderator %}
-				<label class="btn btn-default {% if torrent.comment_locked %}active{% endif %}" title="Lock commenting">
+				<label class="btn btn-default {% if torrent.comment_locked %}active{% endif %}" title="Lock comments">
 					{{ form.is_comment_locked }}
 					<span class="glyphicon glyphicon-check"></span>
 					<span class="glyphicon glyphicon-unchecked"></span>
-					Lock commenting
+					Lock Comments
 				</label>
 				{% endif %}
 			</div>

--- a/nyaa/templates/edit.html
+++ b/nyaa/templates/edit.html
@@ -69,11 +69,11 @@
 				</label>
 				{% endif %}
 				{% if g.user.is_moderator %}
-				<label class="btn btn-default {% if torrent.locked %}active{% endif %}" title="Lock commenting">
-					{{ form.is_locked }}
+				<label class="btn btn-default {% if torrent.comment_locked %}active{% endif %}" title="Lock commenting">
+					{{ form.is_comment_locked }}
 					<span class="glyphicon glyphicon-check"></span>
 					<span class="glyphicon glyphicon-unchecked"></span>
-					Locked
+					Lock commenting
 				</label>
 				{% endif %}
 			</div>

--- a/nyaa/templates/help.html
+++ b/nyaa/templates/help.html
@@ -105,7 +105,7 @@
 {{ linkable_header("IRC Help Channel Policies", "irchelp") }}
 <div>
 	<p>Our IRC help channel is at Rizon <a href="irc://irc.rizon.net/nyaa-help">#nyaa-help</a>. A webchat link
-	pre-filled with our channel is available <a href="https://qchat.rizon.net/?channels=nyaa-help&uio=d4">right here</a>.</p>
+	pre-filled with our channel is available <a href="https://qchat.rizon.net/?channels=nyaa-help">right here</a>.</p>
 
 	<b>Read this to avoid getting banned:</b>
 	<ul>

--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -159,10 +159,10 @@
 					<small data-timestamp-swap data-timestamp-title data-timestamp="{{ comment.edited_utc_timestamp }}" title="{{ comment.edited_time }}">(edited)</small>
 					{% endif %}
 					<div class="comment-actions">
-						{% if g.user.id == comment.user_id and not comment.editing_limit_exceeded %}
+						{% if g.user.id == comment.user_id and not comment.editing_limit_exceeded and (not torrent.locked or g.user.is_moderator) %}
 						<button class="btn btn-xs edit-comment" title="Edit"{% if config.EDITING_TIME_LIMIT %} data-until="{{ comment.editable_until|int }}"{% endif %}>Edit</button>
 						{% endif %}
-						{% if g.user.is_superadmin or g.user.id == comment.user_id %}
+						{% if g.user.is_superadmin or (g.user.id == comment.user_id and not torrent.locked) %}
 						<form class="delete-comment-form" action="{{ url_for('torrents.delete_comment', torrent_id=torrent.id, comment_id=comment.id) }}" method="POST">
 							<button name="submit" type="submit" class="btn btn-danger btn-xs" title="Delete">Delete</button>
 						</form>
@@ -190,6 +190,14 @@
 	</div>
 
 	{% endfor %}
+	{% if torrent.locked %}
+	<div class="alert alert-warning">
+		<p>
+			<i class="fa fa-lock" aria-hidden="true"></i>
+			Commenting has been locked.
+		</p>
+	</div>
+	{% endif %}
 	{% if comment_form %}
 	<form class="comment-box" method="POST">
 		{{ comment_form.csrf_token }}

--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -159,10 +159,10 @@
 					<small data-timestamp-swap data-timestamp-title data-timestamp="{{ comment.edited_utc_timestamp }}" title="{{ comment.edited_time }}">(edited)</small>
 					{% endif %}
 					<div class="comment-actions">
-						{% if g.user.id == comment.user_id and not comment.editing_limit_exceeded and (not torrent.locked or g.user.is_moderator) %}
+						{% if g.user.id == comment.user_id and not comment.editing_limit_exceeded and (not torrent.comment_locked or comment_form) %}
 						<button class="btn btn-xs edit-comment" title="Edit"{% if config.EDITING_TIME_LIMIT %} data-until="{{ comment.editable_until|int }}"{% endif %}>Edit</button>
 						{% endif %}
-						{% if g.user.is_superadmin or (g.user.id == comment.user_id and not torrent.locked) %}
+						{% if g.user.is_superadmin or (g.user.id == comment.user_id and not torrent.comment_locked) %}
 						<form class="delete-comment-form" action="{{ url_for('torrents.delete_comment', torrent_id=torrent.id, comment_id=comment.id) }}" method="POST">
 							<button name="submit" type="submit" class="btn btn-danger btn-xs" title="Delete">Delete</button>
 						</form>
@@ -190,7 +190,7 @@
 	</div>
 
 	{% endfor %}
-	{% if torrent.locked %}
+	{% if torrent.comment_locked %}
 	<div class="alert alert-warning">
 		<p>
 			<i class="fa fa-lock" aria-hidden="true"></i>

--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -194,7 +194,7 @@
 	<div class="alert alert-warning">
 		<p>
 			<i class="fa fa-lock" aria-hidden="true"></i>
-			Commenting has been locked.
+			Comments have been locked.
 		</p>
 	</div>
 	{% endif %}

--- a/nyaa/views/torrents.py
+++ b/nyaa/views/torrents.py
@@ -39,7 +39,8 @@ def view_torrent(torrent_id):
     if flask.request.method == 'POST':
         if not comment_form:
             flask.abort(403)
-        elif comment_form.validate():
+
+        if comment_form.validate():
             comment_text = (comment_form.comment.data or '').strip()
 
             comment = models.Comment(

--- a/nyaa/views/torrents.py
+++ b/nyaa/views/torrents.py
@@ -124,7 +124,7 @@ def edit_torrent(torrent_id):
         if editor.is_moderator and locked_changed:
             log = "Torrent [#{0}]({1}) marked as {2}".format(
                 torrent.id, url,
-                "comment locked" if torrent.comment_locked else "comment unlocked")
+                "comments locked" if torrent.comment_locked else "comments unlocked")
             adminlog = models.AdminLog(log=log, admin_id=editor.id)
             db.session.add(adminlog)
 

--- a/nyaa/views/torrents.py
+++ b/nyaa/views/torrents.py
@@ -123,7 +123,8 @@ def edit_torrent(torrent_id):
         url = flask.url_for('torrents.view', torrent_id=torrent.id)
         if editor.is_moderator and locked_changed:
             log = "Torrent [#{0}]({1}) marked as {2}".format(
-                torrent.id, url, "locked" if torrent.comment_locked else "unlocked")
+                torrent.id, url,
+                "comment locked" if torrent.comment_locked else "comment unlocked")
             adminlog = models.AdminLog(log=log, admin_id=editor.id)
             db.session.add(adminlog)
 


### PR DESCRIPTION
This adds a new flags to torrents, which is only editable by moderators and admins. If checked, it does not allow unprivileged users to post, edit or delete comments on that torrent.

Here's what it looks like when a comment thread is locked:
![commentlocking](https://user-images.githubusercontent.com/308818/35475146-753bceb8-0399-11e8-9279-53a219de1ded.png)

What I haven't tested so far is whether all the checks still hold up when you curl pages directly, but theoretically they should.
