### PR TITLE
Feature/shadow flagging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__
 
 # Editors
 /.vscode
+/.idea
 
 # Databases
 *.sql

--- a/es_mapping.yml
+++ b/es_mapping.yml
@@ -102,6 +102,8 @@ mappings:
         type: boolean
       hidden:
         type: boolean
+      shadowed:
+        type: boolean
       deleted:
         type: boolean
       has_torrent:

--- a/import_to_es.py
+++ b/import_to_es.py
@@ -58,6 +58,7 @@ def mk_es(t, index_name):
             # for at least a few months.
             "hidden": bool(t.hidden),
             "deleted": bool(t.deleted),
+            "shadowed": bool(t.shadowed),
             "has_torrent": t.has_torrent,
             # Stats
             "download_count": t.stats.download_count,

--- a/nyaa/forms.py
+++ b/nyaa/forms.py
@@ -264,6 +264,7 @@ class EditForm(FlaskForm):
     is_anonymous = BooleanField('Anonymous')
     is_complete = BooleanField('Complete')
     is_trusted = BooleanField('Trusted')
+    is_shadowed = BooleanField('Shadowed')
 
     information = StringField('Information', [
         Length(max=255, message='Information must be at most %(max)d characters long.')

--- a/nyaa/models.py
+++ b/nyaa/models.py
@@ -23,6 +23,7 @@ app = flask.current_app
 
 if config['USE_MYSQL']:
     from sqlalchemy.dialects import mysql
+
     BinaryType = mysql.BINARY
     TextType = mysql.TEXT
     MediumBlobType = mysql.MEDIUMBLOB
@@ -36,7 +37,6 @@ else:
     COL_UTF8_GENERAL_CI = 'NOCASE'
     COL_UTF8MB4_BIN = None
     COL_ASCII_GENERAL_CI = 'NOCASE'
-
 
 # For property timestamps
 UTC_EPOCH = datetime.utcfromtimestamp(0)
@@ -100,6 +100,7 @@ class TorrentFlags(IntEnum):
     COMPLETE = 16
     DELETED = 32
     BANNED = 64
+    SHADOWED = 128
 
 
 class TorrentBase(DeclarativeHelperBase):
@@ -258,9 +259,9 @@ class TorrentBase(DeclarativeHelperBase):
     trusted = FlagProperty(TorrentFlags.TRUSTED)
     remake = FlagProperty(TorrentFlags.REMAKE)
     complete = FlagProperty(TorrentFlags.COMPLETE)
+    shadowed = FlagProperty(TorrentFlags.SHADOWED)
 
     # Class methods
-
     @classmethod
     def by_id(cls, id):
         return cls.query.get(id)
@@ -577,6 +578,7 @@ class User(db.Model):
     @classmethod
     def by_username(cls, username):
         def isascii(s): return len(s) == len(s.encode())
+
         if not isascii(username):
             return None
 

--- a/nyaa/models.py
+++ b/nyaa/models.py
@@ -100,7 +100,7 @@ class TorrentFlags(IntEnum):
     COMPLETE = 16
     DELETED = 32
     BANNED = 64
-    SHADOWED = 128
+    SHADOWED = 256
 
 
 class TorrentBase(DeclarativeHelperBase):

--- a/nyaa/search.py
+++ b/nyaa/search.py
@@ -172,12 +172,12 @@ def search_elastic(term='', user=None, sort='id', order='desc',
                     default_operator="AND",
                     query=term)
 
-    if user and not admin:
+    if logged_in_user and not admin:
         # Hide all SHADOWED torrents not owned by user
-        s.filter('bool', filter=[Q('term', shadowed=False) | Q('term', uploader_id=user.id)])
-    elif not user:
+        s = s.filter('bool', filter=[Q('term', shadowed=False) | Q('term', uploader_id=logged_in_user.id)])
+    elif not logged_in_user:
         # Hide all SHADOWED torrents
-        s.filter('term', shadowed=False)
+        s = s.filter('term', shadowed=False)
 
     # User view (/user/username)
     if user:

--- a/nyaa/search.py
+++ b/nyaa/search.py
@@ -174,7 +174,8 @@ def search_elastic(term='', user=None, sort='id', order='desc',
 
     if logged_in_user and not admin:
         # Hide all SHADOWED torrents not owned by user
-        s = s.filter('bool', filter=[Q('term', shadowed=False) | Q('term', uploader_id=logged_in_user.id)])
+        s = s.filter('bool', filter=[Q('term', shadowed=False) |
+                                     Q('term', uploader_id=logged_in_user.id)])
     elif not logged_in_user:
         # Hide all SHADOWED torrents
         s = s.filter('term', shadowed=False)

--- a/nyaa/search.py
+++ b/nyaa/search.py
@@ -121,6 +121,9 @@ def search_elastic(term='', user=None, sort='id', order='desc',
         '3'  # Only completed
     ]
 
+    if logged_in_user and logged_in_user.is_moderator:
+        quality_keys.append('4')
+
     if quality_filter.lower() not in quality_keys:
         flask.abort(400)
 
@@ -227,6 +230,8 @@ def search_elastic(term='', user=None, sort='id', order='desc',
         s = s.filter('term', trusted=True)
     elif quality_filter == 3:
         s = s.filter('term', complete=True)
+    elif quality_filter == 4:
+        s = s.filter('term', shadowed=True)
 
     # Apply sort
     s = s.sort(es_sort)
@@ -306,6 +311,9 @@ def search_db(term='', user=None, sort='id', order='desc', category='0_0',
         '2': (models.TorrentFlags.TRUSTED, True),
         '3': (models.TorrentFlags.COMPLETE, True)
     }
+
+    if logged_in_user and logged_in_user.is_moderator:
+        filter_keys['4'] = (models.TorrentFlags.SHADOWED, True)
 
     sentinel = object()
     filter_tuple = filter_keys.get(quality_filter.lower(), sentinel)

--- a/nyaa/search.py
+++ b/nyaa/search.py
@@ -172,6 +172,13 @@ def search_elastic(term='', user=None, sort='id', order='desc',
                     default_operator="AND",
                     query=term)
 
+    if user and not admin:
+        # Hide all SHADOWED torrents not owned by user
+        s.filter('bool', filter=[Q('term', shadowed=False) | Q('term', uploader_id=user.id)])
+    elif not user:
+        # Hide all SHADOWED torrents
+        s.filter('term', shadowed=False)
+
     # User view (/user/username)
     if user:
         s = s.filter('term', uploader_id=user)

--- a/nyaa/templates/edit.html
+++ b/nyaa/templates/edit.html
@@ -45,6 +45,14 @@
 					<span class="glyphicon glyphicon-unchecked"></span>
 					Hidden
 				</label>
+                {% if g.user.is_moderator %}
+                <label class="btn btn-info {% if torrent.shadowed %}active{% endif %}" title="Shadow torrent from listing">
+					{{ form.is_shadowed }}
+					<span class="glyphicon glyphicon-check"></span>
+					<span class="glyphicon glyphicon-unchecked"></span>
+					Shadowed
+				</label>
+                {% endif %}
 			</div>
 			<div class="hidden-xl"><br></div>
 			<div class="btn-group" data-toggle="buttons">

--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -267,6 +267,9 @@
 									<option value="0" title="No filter" {% if search is defined and search["quality_filter"] == "0" %}selected{% else %}selected{% endif %}>No filter</option>
 									<option value="1" title="No remakes" {% if search is defined and search["quality_filter"] == "1" %}selected{% endif %}>No remakes</option>
 									<option value="2" title="Trusted only" {% if search is defined and search["quality_filter"] == "2" %}selected{% endif %}>Trusted only</option>
+                                    {% if g.user.is_moderator %}
+                                        <option value="4" title="Shadowed only" {% if search is defined and search["quality_filter"] == "4" %}selected{% endif %}>Shadowed only</option>
+                                    {% endif %}
 								</select>
 							</div>
 

--- a/nyaa/templates/search_results.html
+++ b/nyaa/templates/search_results.html
@@ -57,7 +57,7 @@
 		<tbody>
 			{% set torrents = torrent_query if use_elastic else torrent_query.items %}
 			{% for torrent in torrents %}
-			<tr class="{% if torrent.deleted %}deleted{% elif torrent.hidden %}warning{% elif torrent.remake %}danger{% elif torrent.trusted %}success{% elif torrent.shadowed and g.user and g.user.level >= 2 %}info{% else %}default{% endif %}">
+			<tr class="{% if torrent.deleted %}deleted{% elif torrent.hidden %}warning{% elif torrent.remake %}danger{% elif torrent.trusted %}success{% elif torrent.shadowed and g.user and g.user.is_moderator %}info{% else %}default{% endif %}">
 				{% set cat_id = use_elastic and ((torrent.main_category_id|string) + '_' + (torrent.sub_category_id|string)) or torrent.sub_category.id_as_string %}
 				{% set icon_dir = config.SITE_FLAVOR %}
 				<td style="padding:0 4px;">

--- a/nyaa/templates/search_results.html
+++ b/nyaa/templates/search_results.html
@@ -57,7 +57,7 @@
 		<tbody>
 			{% set torrents = torrent_query if use_elastic else torrent_query.items %}
 			{% for torrent in torrents %}
-			<tr class="{% if torrent.deleted %}deleted{% elif torrent.hidden %}warning{% elif torrent.remake %}danger{% elif torrent.trusted %}success{% else %}default{% endif %}">
+			<tr class="{% if torrent.deleted %}deleted{% elif torrent.hidden %}warning{% elif torrent.remake %}danger{% elif torrent.trusted %}success{% elif torrent.shadowed and g.user and g.user.level >= 2 %}info{% else %}default{% endif %}">
 				{% set cat_id = use_elastic and ((torrent.main_category_id|string) + '_' + (torrent.sub_category_id|string)) or torrent.sub_category.id_as_string %}
 				{% set icon_dir = config.SITE_FLAVOR %}
 				<td style="padding:0 4px;">

--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -6,7 +6,7 @@
 {% endblock %}
 {% block body %}
 {% from "_formhelpers.html" import render_field %}
-<div class="panel panel-{% if torrent.deleted %}deleted{% elif torrent.remake %}danger{% elif torrent.trusted %}success{% elif torrent.shadowed and g.user and g.user.level >= 2 %}info{% else %}default{% endif %}">
+<div class="panel panel-{% if torrent.deleted %}deleted{% elif torrent.remake %}danger{% elif torrent.trusted %}success{% elif torrent.shadowed and g.user and g.user.is_moderator %}info{% else %}default{% endif %}">
 	<div class="panel-heading"{% if torrent.hidden %} style="background-color: darkgray;"{% endif %}>
 		<h3 class="panel-title">
 			{% if can_edit %}

--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -6,7 +6,7 @@
 {% endblock %}
 {% block body %}
 {% from "_formhelpers.html" import render_field %}
-<div class="panel panel-{% if torrent.deleted %}deleted{% elif torrent.remake %}danger{% elif torrent.trusted %}success{% else %}default{% endif %}">
+<div class="panel panel-{% if torrent.deleted %}deleted{% elif torrent.remake %}danger{% elif torrent.trusted %}success{% elif torrent.shadowed and g.user and g.user.level >= 2 %}info{% else %}default{% endif %}">
 	<div class="panel-heading"{% if torrent.hidden %} style="background-color: darkgray;"{% endif %}>
 		<h3 class="panel-title">
 			{% if can_edit %}

--- a/nyaa/views/torrents.py
+++ b/nyaa/views/torrents.py
@@ -121,6 +121,7 @@ def edit_torrent(torrent_id):
         deleted_changed = torrent.deleted != form.is_deleted.data
         if editor.is_moderator:
             torrent.deleted = form.is_deleted.data
+            torrent.shadowed = form.is_shadowed.data
 
         url = flask.url_for('torrents.view', torrent_id=torrent.id)
         if deleted_changed and editor.is_moderator:

--- a/sync_es.py
+++ b/sync_es.py
@@ -101,6 +101,7 @@ def reindex_torrent(t, index_name):
         # for at least a few months.
         "hidden": bool(f & TorrentFlags.HIDDEN),
         "deleted": bool(f & TorrentFlags.DELETED),
+        "shadowed": bool(f & TorrentFlags.SHADOWED),
         "has_torrent": bool(t['has_torrent']),
     }
     # update, so we don't delete the stats if present


### PR DESCRIPTION
This pull request allows shadowing of torrents needed for #351 

A shadowed torrent isn't visible from the index unless you're ~~an admin~~ a moderator or the user that uploaded the torrent, torrent is still available for viewing from invidual page

TODO

* [x] ES support
* [x] UI feedback for admin roles
* [x] filter for shadowed torrents for admin roles
* [x] Add buttons for admin roles to shadow or unshadow a torrent