### PR TITLE
Undo responsive table for reports

### DIFF
--- a/nyaa/static/css/main.css
+++ b/nyaa/static/css/main.css
@@ -480,6 +480,10 @@ body.dark .comment-panel:target {
 	border-color: white;
 }
 
+body.dark .table > table {
+	background-color: #323232;
+}
+
 /* trusted */
 body.dark .torrent-list > tbody > tr.success > td {
 	color: inherit;

--- a/nyaa/templates/reports.html
+++ b/nyaa/templates/reports.html
@@ -2,7 +2,7 @@
 {% block title %}Reports :: {{ config.SITE_NAME }}{% endblock %}
 {% block body %}
 {% from "_formhelpers.html" import render_field %}
-	<div class="table-responsive">
+	<div class="table">
 		<table class="table table-bordered table-hover table-striped table-condensed">
 			<thead>
 			<tr>


### PR DESCRIPTION
I opted for `table-responsive` since the other option was to duplicate a CSS rule already present in bootstrap dark, this PR does that instead.