### PR TITLE
Don't submit reports for already banned torrents

### DIFF
--- a/nyaa/views/torrents.py
+++ b/nyaa/views/torrents.py
@@ -401,6 +401,12 @@ def submit_report(torrent_id):
         flask.abort(403)
 
     form = forms.ReportForm(flask.request.form)
+    torrent = models.Torrent.by_id(torrent_id)
+    if not torrent:
+        flask.abort(404)
+    if torrent.banned:
+        flask.flash("The torrent you've tried to report is already banned.", 'danger')
+        flask.abort(404)
 
     if flask.request.method == 'POST' and form.validate():
         report_reason = form.reason.data


### PR DESCRIPTION
If users kept their page open for a while before reporting a torrent, and mods got it in the meantime, users could still submit reports for that torrent. This is silly and really doesn't need to happen.