### PR TITLE
Redo nuke functionality

### DIFF
--- a/nyaa/forms.py
+++ b/nyaa/forms.py
@@ -284,7 +284,6 @@ class DeleteForm(FlaskForm):
 class BanForm(FlaskForm):
     ban_user = SubmitField("Delete & Ban and Ban User")
     ban_userip = SubmitField("Delete & Ban and Ban User+IP")
-    nuke = SubmitField("Delete & Ban all torrents")
     unban = SubmitField("Unban")
 
     _validator = DataRequired()
@@ -297,6 +296,10 @@ class BanForm(FlaskForm):
         _validate_reason,
         Length(max=1024, message='Reason must be at most %(max)d characters long.')
     ])
+
+
+class NukeForm(FlaskForm):
+    nuke_torrents = SubmitField("\U0001F4A3 Nuke Torrents")
 
 
 class UploadForm(FlaskForm):

--- a/nyaa/templates/user.html
+++ b/nyaa/templates/user.html
@@ -104,30 +104,34 @@
 							</div>
 						</div>
 						<div class="row">
-							<div class="col-md-3 text-left">
+							<div class="col-md-6 text-left">
 								{% if not user.is_banned %}
 								{{ ban_form.ban_user(value="Ban User", class="btn btn-danger") }}
 								{% else %}
 								<button type="button" class="btn btn-danger disabled">Already banned</button>
 								{% endif %}
 							</div>
-							<div class="col-md-3 text-center">
+							<div class="col-md-6 text-right">
 								{% if not ipbanned %}
 								{{ ban_form.ban_userip(value="Ban User+IP", class="btn btn-danger") }}
 								{% else %}
 								<button type="button" class="btn btn-danger disabled">Already IP banned</button>
 								{% endif %}
 							</div>
-							<div class="col-md-6 text-right">
-								{% if g.user.is_superadmin %}
-								{{ ban_form.nuke(value="\U0001F4A3 Nuke Torrents", class="btn btn-danger") }}
-								{% else %}
-								<button type="button" class="btn btn-danger disabled">&#x1f4a3; Nuke Torrents</button>
-								{% endif %}
-							</div>
 						</div>
 						{% endif %}
 					</form>
+					{% if g.user.is_superadmin %}
+					<hr>
+					<form method="POST" onsubmit="return prompt('Please type {{ user.username }} to confirm').toLowerCase() == '{{ user.username }}'.toLowerCase()">
+						{{ nuke_form.csrf_token }}
+						<div class="row">
+							<div class="col-md-6 text-left">
+								{{ nuke_form.nuke_torrents(class="btn btn-danger", formaction=url_for('users.nuke_user_torrents', user_name=user.username)) }}
+							</div>
+						</div>
+					</form>
+					{% endif %}
 				</div>
 			</div>
 		</div>

--- a/nyaa/utils.py
+++ b/nyaa/utils.py
@@ -4,6 +4,8 @@ import random
 import string
 from collections import OrderedDict
 
+import flask
+
 
 def sha1_hash(input_bytes):
     """ Hash given bytes with hashlib.sha1 and return the digest (as bytes) """
@@ -78,3 +80,13 @@ def chain_get(source, *args):
         if value is not sentinel:
             return value
     return None
+
+
+def admin_only(f):
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        if flask.g.user and flask.g.user.is_superadmin:
+            return f(*args, **kwargs)
+        else:
+            flask.abort(401)
+    return wrapper


### PR DESCRIPTION
This started out as a simple rebase, but then I rebased the wrong branches and it all got confusing, so here it is as a new dank commit.

We now have an `@admin_only` decorator, and we ask for confirmation before we nuke. We can also see the nuke button when users are banned, and nuking is a separate endpoint with a separate form.

Additionally, it now uses the new tracker API.