### PR TITLE
Add some rel attributes to links inside markdown

### DIFF
--- a/nyaa/static/js/main.js
+++ b/nyaa/static/js/main.js
@@ -212,6 +212,13 @@ markdown.renderer.rules.table_open = function (tokens, idx) {
 	// Format tables nicer (bootstrap). Force auto-width (default is 100%)
 	return '<table class="table table-striped table-bordered" style="width: auto;">';
 }
+var defaultRender = markdown.renderer.rules.link_open || function(tokens, idx, options, env, self) {
+	return self.renderToken(tokens, idx, options);
+};
+markdown.renderer.rules.link_open = function (tokens, idx, options, env, self) {
+	tokens[idx].attrPush(['rel', 'noopener nofollow noreferrer']);
+	return defaultRender(tokens, idx, options, env, self);
+}
 
 // Initialise markdown editors on page
 document.addEventListener("DOMContentLoaded", function() {


### PR DESCRIPTION
I currently don't differentiate between "trusted" markdown and untrusted, but this should be good enough. Basically tells the browser not to send a referrer, and (not sure if relevant here) not to expose a window opener object. Also tells search engines that the link is not endorsed with "nofollow".