### PR TITLE
[Config Change] Various Gravatar-related changes

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -152,3 +152,7 @@ ES_INDEX_NAME = SITE_FLAVOR
 # Time limit for editing a comment after it has been posted (seconds)
 # Set to 0 to disable
 EDITING_TIME_LIMIT = 0
+
+# Whether to use Gravatar or just always use the default avatar
+# (Useful if run as development instance behind NAT/firewall)
+ENABLE_GRAVATAR = True

--- a/nyaa/__init__.py
+++ b/nyaa/__init__.py
@@ -90,4 +90,10 @@ def create_app(config):
     app.register_blueprint(api_blueprint)
     register_views(app)
 
+    # Pregenerate some URLs to avoid repeat url_for calls
+    if 'SERVER_NAME' in app.config and app.config['SERVER_NAME']:
+        with app.app_context():
+            url = flask.url_for('static', filename='img/avatar/default.png', _external=True)
+            app.config['DEFAULT_GRAVATAR_URL'] = url
+
     return app

--- a/nyaa/models.py
+++ b/nyaa/models.py
@@ -517,13 +517,18 @@ class User(db.Model):
         return all(checks)
 
     def gravatar_url(self):
+        if 'DEFAULT_GRAVATAR_URL' in app.config:
+            default_url = app.config['DEFAULT_GRAVATAR_URL']
+        else:
+            default_url = flask.url_for('static', filename='img/avatar/default.png',
+                                        _external=True)
         if app.config['ENABLE_GRAVATAR']:
             # from http://en.gravatar.com/site/implement/images/python/
             params = {
                 # Image size (https://en.gravatar.com/site/implement/images/#size)
                 's': 120,
                 # Default image (https://en.gravatar.com/site/implement/images/#default-image)
-                'd': flask.url_for('static', filename='img/avatar/default.png', _external=True),
+                'd': default_url,
                 # Image rating (https://en.gravatar.com/site/implement/images/#rating)
                 # Nyaa: PG-rated, Sukebei: X-rated
                 'r': 'pg' if app.config['SITE_FLAVOR'] == 'nyaa' else 'x',
@@ -532,7 +537,7 @@ class User(db.Model):
             return 'https://www.gravatar.com/avatar/{}?{}'.format(
                 md5(self.email.encode('utf-8').lower()).hexdigest(), urlencode(params))
         else:
-            return flask.url_for('static', filename='img/avatar/default.png')
+            return default_url
 
     @property
     def userlevel_str(self):

--- a/nyaa/models.py
+++ b/nyaa/models.py
@@ -517,19 +517,22 @@ class User(db.Model):
         return all(checks)
 
     def gravatar_url(self):
-        # from http://en.gravatar.com/site/implement/images/python/
-        params = {
-            # Image size (https://en.gravatar.com/site/implement/images/#size)
-            's': 120,
-            # Default image (https://en.gravatar.com/site/implement/images/#default-image)
-            'd': flask.url_for('static', filename='img/avatar/default.png', _external=True),
-            # Image rating (https://en.gravatar.com/site/implement/images/#rating)
-            # Nyaa: PG-rated, Sukebei: X-rated
-            'r': 'pg' if app.config['SITE_FLAVOR'] == 'nyaa' else 'x',
-        }
-        # construct the url
-        return 'https://www.gravatar.com/avatar/{}?{}'.format(
-            md5(self.email.encode('utf-8').lower()).hexdigest(), urlencode(params))
+        if app.config['ENABLE_GRAVATAR']:
+            # from http://en.gravatar.com/site/implement/images/python/
+            params = {
+                # Image size (https://en.gravatar.com/site/implement/images/#size)
+                's': 120,
+                # Default image (https://en.gravatar.com/site/implement/images/#default-image)
+                'd': flask.url_for('static', filename='img/avatar/default.png', _external=True),
+                # Image rating (https://en.gravatar.com/site/implement/images/#rating)
+                # Nyaa: PG-rated, Sukebei: X-rated
+                'r': 'pg' if app.config['SITE_FLAVOR'] == 'nyaa' else 'x',
+            }
+            # construct the url
+            return 'https://www.gravatar.com/avatar/{}?{}'.format(
+                md5(self.email.encode('utf-8').lower()).hexdigest(), urlencode(params))
+        else:
+            return flask.url_for('static', filename='img/avatar/default.png')
 
     @property
     def userlevel_str(self):


### PR DESCRIPTION
The first commit adds an option `ENABLE_GRAVATAR`, which can be disabled to have flask always serve the default avatar URL. This is useful in situations where gravatar cannot reach the host nyaa is running on, e.g. if you're developing behind a firewall.

The second commit pre-generates the default URL if `SERVER_NAME` is set, which saves one `url_for` call per shown avatar. On my machine, a `url_for` takes about 0.3 ms, so in a 300 comment shitfest I'd shave off 90 ms in this situation.

Whether or not `SERVER_NAME` is set depends on how the application is run, so I'm not sure whether this works in production.