### PR TITLE
Use Flask-Assets to minify self-hosted JS files

### DIFF
--- a/nyaa/__init__.py
+++ b/nyaa/__init__.py
@@ -81,6 +81,11 @@ def create_app(config):
 
     # Assets
     assets.init_app(app)
+    main_js = Bundle('js/main.js', filters='rjsmin', output='js/main.min.js')
+    bs_js = Bundle('js/bootstrap-select.js', filters='rjsmin',
+                   output='js/bootstrap-select.min.js')
+    assets.register('main_js', main_js)
+    assets.register('bs_js', bs_js)
     # css = Bundle('style.scss', filters='libsass',
     #             output='style.css', depends='**/*.scss')
     # assets.register('style_all', css)

--- a/nyaa/__init__.py
+++ b/nyaa/__init__.py
@@ -81,6 +81,7 @@ def create_app(config):
 
     # Assets
     assets.init_app(app)
+    assets._named_bundles = {}  # Hack to fix state carrying over in tests
     main_js = Bundle('js/main.js', filters='rjsmin', output='js/main.min.js')
     bs_js = Bundle('js/bootstrap-select.js', filters='rjsmin',
                    output='js/bootstrap-select.min.js')

--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -45,8 +45,12 @@
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/markdown-it/8.3.1/markdown-it.min.js" integrity="sha256-3WZyZQOe+ql3pLo90lrkRtALrlniGdnf//gRpW0UQks=" crossorigin="anonymous"></script>
 		<!-- Modified to not apply border-radius to selectpickers and stuff so our navbar looks cool -->
-		<script src="{{ static_cachebuster('js/bootstrap-select.js') }}"></script>
-		<script src="{{ static_cachebuster('js/main.js') }}"></script>
+		{% assets "bs_js" %}
+		<script src="{{ static_cachebuster('js/bootstrap-select.min.js') }}"></script>
+		{% endassets %}
+		{% assets "main_js" %}
+		<script src="{{ static_cachebuster('js/main.min.js') }}"></script>
+		{% endassets %}
 
 		<!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
 		<!--[if lt IE 9]>


### PR DESCRIPTION
By having Flask-Assets minify the two JS files we ship, namely `main.js` and `bootstrap-select.js`, we can shave off 28406 bytes.

The minified files are generated on startup. If one wishes to manually clean them up or build them, they can use the `flask assets` management command, e.g. `flask assets clean`.