### PR TITLE
Fix nuke button prompt

### DIFF
--- a/nyaa/templates/user.html
+++ b/nyaa/templates/user.html
@@ -123,7 +123,7 @@
 					</form>
 					{% if g.user.is_superadmin %}
 					<hr>
-					<form method="POST" onsubmit="return prompt('Please type {{ user.username }} to confirm').toLowerCase() == '{{ user.username }}'.toLowerCase()">
+					<form method="POST" onsubmit="return prompt('Please type {{ user.username }} to confirm') == '{{ user.username }}'">
 						{{ nuke_form.csrf_token }}
 						<div class="row">
 							<div class="col-md-6 text-left">


### PR DESCRIPTION
Hitting the cancel button does not return "", but null. Therefore the toLowerCase() fails, and throwing an exception means "sure go ahead submitting this" to JS for some godforsaken reason.

Just remove the toLowerCase for now, have people type the names properly.