### PR TITLE
user page: add manual activation button for mods

### DIFF
--- a/nyaa/forms.py
+++ b/nyaa/forms.py
@@ -408,6 +408,7 @@ class UploadForm(FlaskForm):
 
 class UserForm(FlaskForm):
     user_class = SelectField('Change User Class')
+    activate_user = SubmitField('Activate User')
 
     def validate_user_class(form, field):
         if not field.data:

--- a/nyaa/models.py
+++ b/nyaa/models.py
@@ -612,6 +612,10 @@ class User(db.Model):
         return self.status == UserStatusType.BANNED
 
     @property
+    def is_active(self):
+        return self.status != UserStatusType.INACTIVE
+
+    @property
     def age(self):
         '''Account age in seconds'''
         return (datetime.utcnow() - self.created_time).total_seconds()

--- a/nyaa/templates/user.html
+++ b/nyaa/templates/user.html
@@ -42,14 +42,21 @@
 				</div>
 			</div>
 			{% if admin_form %}
-			<div class="row">
-				<div class="col-md-6">
-					<form method="POST">
-						{{ admin_form.csrf_token }}
+			<form method="POST">
+				{{ admin_form.csrf_token }}
+				<div class="row">
+					<div class="col-md-6">
 						{{ render_menu_with_button(admin_form.user_class) }}
-					</form>
+					</div>
 				</div>
-			</div>
+				{% if not user.is_active %}
+				<div class="row">
+					<div class="col-md-6">
+						{{ admin_form.activate_user(class="btn btn-primary") }}
+					</div>
+				</div>
+				{% endif %}
+			</form>
 			<br>
 			{% endif %}
 		</div>

--- a/nyaa/views/users.py
+++ b/nyaa/views/users.py
@@ -59,10 +59,10 @@ def view_user(user_name):
 
         if admin_form.activate_user.data and not user.is_banned:
             user.status = models.UserStatusType.ACTIVE
-            adminlog2 = models.AdminLog("[{}]({}) was manually activated"
+            adminlog = models.AdminLog("[{}]({}) was manually activated"
                                         .format(user_name, url),
                                         admin_id=flask.g.user.id)
-            db.session.add(adminlog2)
+            db.session.add(adminlog)
 
         db.session.add(user)
         db.session.commit()

--- a/nyaa/views/users.py
+++ b/nyaa/views/users.py
@@ -47,20 +47,24 @@ def view_user(user_name):
     url = flask.url_for('users.view_user', user_name=user.username)
     if flask.request.method == 'POST' and admin_form and not doban and admin_form.validate():
         selection = admin_form.user_class.data
-        log = None
-        if selection == 'regular':
-            user.level = models.UserLevelType.REGULAR
-            log = "[{}]({}) changed to regular user".format(user_name, url)
-        elif selection == 'trusted':
-            user.level = models.UserLevelType.TRUSTED
-            log = "[{}]({}) changed to trusted user".format(user_name, url)
-        elif selection == 'moderator':
-            user.level = models.UserLevelType.MODERATOR
-            log = "[{}]({}) changed to moderator user".format(user_name, url)
+        mapping = {'regular': models.UserLevelType.REGULAR,
+                   'trusted': models.UserLevelType.TRUSTED,
+                   'moderator': models.UserLevelType.MODERATOR}
 
-        adminlog = models.AdminLog(log=log, admin_id=flask.g.user.id)
+        if mapping[selection] != user.level:
+            user.level = mapping[selection]
+            log = "[{}]({}) changed to {} user".format(user_name, url, selection)
+            adminlog = models.AdminLog(log=log, admin_id=flask.g.user.id)
+            db.session.add(adminlog)
+
+        if admin_form.activate_user.data and not user.is_banned:
+            user.status = models.UserStatusType.ACTIVE
+            adminlog2 = models.AdminLog("[{}]({}) was manually activated"
+                                        .format(user_name, url),
+                                        admin_id=flask.g.user.id)
+            db.session.add(adminlog2)
+
         db.session.add(user)
-        db.session.add(adminlog)
         db.session.commit()
 
         return flask.redirect(url)

--- a/nyaa/views/users.py
+++ b/nyaa/views/users.py
@@ -60,8 +60,8 @@ def view_user(user_name):
         if admin_form.activate_user.data and not user.is_banned:
             user.status = models.UserStatusType.ACTIVE
             adminlog = models.AdminLog("[{}]({}) was manually activated"
-                                        .format(user_name, url),
-                                        admin_id=flask.g.user.id)
+                                       .format(user_name, url),
+                                       admin_id=flask.g.user.id)
             db.session.add(adminlog)
 
         db.session.add(user)


### PR DESCRIPTION
Moderators can press this button on inactive users to manually activate their accounts.

Furthermore, the admin form code has been refactored a bit, reducing some code duplication.