### PR TITLE
[ES Change] Improve Elasticsearch term quoting

### DIFF
--- a/es_mapping.yml
+++ b/es_mapping.yml
@@ -32,13 +32,19 @@ settings:
         filter:
           - lowercase
           - word_delimit
-          # These should be enough, as my_index_analyzer will match the rest
+          # Skip tokens shorter than N characters,
+          # since they're already indexed in the main field
+          - fullword_min
 
     filter:
       my_ngram:
         type: edgeNGram
         min_gram: 1
         max_gram: 15
+      fullword_min:
+        type: length
+        # Remember to change this if you change the max_gram below!
+        min: 16
       resolution:
         type: pattern_capture
         patterns: ["(\\d+)[xX](\\d+)"]

--- a/es_mapping.yml
+++ b/es_mapping.yml
@@ -23,6 +23,11 @@ settings:
           - my_ngram
           - word_delimit
           - trim_zero
+      # For exact matching - simple lowercase + whitespace delimiter
+      exact_analyzer:
+        tokenizer: whitespace
+        filter:
+          - lowercase
       # For matching full words longer than the ngram limit (15 chars)
       my_fullword_index_analyzer:
         type: custom
@@ -91,6 +96,10 @@ mappings:
           fullword:
             type: text
             analyzer: my_fullword_index_analyzer
+          # Stored for exact phrase matching
+          exact:
+            type: text
+            analyzer: exact_analyzer
       created_time:
         type: date
         # Only in the ES index for generating magnet links


### PR DESCRIPTION
This PR changes the Elasticsearch mapping.

```
This commit adds a new .exact subfield to display_name, which holds a
barely-filtered version of the original title we can do "literal"
matching against. This is not real substring matching, but quoting
terms now actually does something!

Implements a simple preprocessor for the search terms to extract quoted
parts from the search terms, optionally prefixed with - to negate them.
The preprocessor will create a query that'll join all three query-types:
the simple_query_string, must-phrases and must-not-phrases.
```
tldr: quotation marks now have (more of) the expected effect now.

Also includes an optimization for the `fullword` field - don't index tokens shorter than the ngram max.