### PR TITLE
Update leechers-paradise tracker domain

### DIFF
--- a/trackers.txt
+++ b/trackers.txt
@@ -4,4 +4,4 @@
 udp://open.stealth.si:80/announce
 udp://tracker.opentrackr.org:1337/announce
 udp://tracker.coppersurfer.tk:6969/announce
-udp://tracker.leechers-paradise.org:6969/announce
+udp://tracker.open-internet.nl:6969/announce


### PR DESCRIPTION
Leechers-paradise.org changed their primary domain. [Their website](http://leechers-paradise.org/) says "I also moved the primary domain from leechers-paradise.org to open-internet.nl." It also says old domains will work, but perhaps it is still better to change it.