### PR TITLE
Make help easier to understand & fix grammar

### DIFF
--- a/nyaa/templates/help.html
+++ b/nyaa/templates/help.html
@@ -14,12 +14,12 @@
 	<ul>
 		<li>Torrents uploaded by trusted users.</li>
 	</ul>
-	<span style="color:red; font-weight: bold;">Red</span> entries (remake) are torrents that matching any of the following:
+	<span style="color:red; font-weight: bold;">Red</span> entries (remake) are torrents that match any of the following:
 	<ul>
-		<li>Reencode of original release.</li>
-		<li>Remux of another uploader's original release for hardsubbing and/or fixing purposes.</li>
-		<li>Reupload of original release using non-original file names.</li>
-		<li>Reupload of original release with missing and/or unrelated additional files.</li>
+		<li>Reencodes of original releases.</li>
+		<li>Remuxes of another uploader's original releases that are hardsubbed and/or fixed</li>
+		<li>Reuploads of original releases using non-original file names.</li>
+		<li>Reuploads of original releases with missing and/or unrelated additional files.</li>
 	</ul>
 	<span style="color:orange; font-weight: bold;">Orange</span> entries are:
 	<ul>
@@ -33,30 +33,25 @@
 
 {{ linkable_header("Using the Search Engine", "using-search") }}
 <div>
-	Search results can be filtered by category, remake, trusted, and users.
-	The results can be further sorted by size, date, seeders, leechers, completed count, and comment count.
-</div>
-<div>
-	You can combine search terms with the <kbd>|</kbd> operator, such as
-	<kbd>foo|bar</kbd>, to match any of the words instead all of them.
-</div>
-<div>
-	To exclude results matching a certain word, prefix them with <kbd>-</kbd>,
-	e.g. <kbd>foo -bar</kbd>, which will return torrents with <em>foo</em> in the
-	name, but not those which have <em>bar</em> in the name as well.
-</div>
-<div>
-	If you want to search for a several-word expression in its entirety, you can
-	surround searches with <kbd>"</kbd> (double quotes), such as
-	<kbd>"foo bar"</kbd>, which would match torrents named <em>foo bar</em> but not
-	those named <em>bar foo</em>. You may also use the aforementioned <kbd>|</kbd> to group
-	phrases together: <kbd>"foo bar"|"foo baz"</kbd>. You can negate the entire
-	group with <kbd>-</kbd> (e.g. <kbd>-"foo bar"|"foo baz"</kbd>), but not single items.
-</div>
-<div>
-	You can also use <kbd>(</kbd> and <kbd>)</kbd> to signify precedence, but quoted strings do
-	not honor this. Using <kbd>(hello world) "foo bar"</kbd> is fine, but quoted strings inside
-	the parentheses will lead to unexpected results.
+<span style="font-weight: bold;">Filtering</span>
+	<ul>
+		<li>Search results can be filtered by category and whether they are remakes or provided by a trusted uploader using the drop down menus next to the search bar</li>
+	  <li>Results can be further sorted by size, date, seeders, number of completed downloads, and number of comments</li>
+	</ul>
+<span style="font-weight: bold;">Search Operators</span>
+	<ul>
+		<li>You can combine search terms with the <kbd>|</kbd> operator, to match any of the terms instead of all of them</li>
+		<li>To exclude results with a certain keyword, prefix it with <kbd>-</kbd></li>
+			<ul>
+				<li>For example, searching for <kbd>foo -bar</kbd> will display results which contain <i>foo</i>, but not  <i>bar</i></li>
+			</ul>
+		<li>To search for a multi-word term, surround all the words with <kbd>""</kbd>(double quotes)</li>
+			<ul>
+				<li>Searching for <kbd>"foo bar"</kbd> would return results containing exactly <i>foo bar</i></li>
+				<li>You may also use <kbd>|</kbd> and <kbd>-</kbd> to manipulate phrases as if they were single keywords</li>
+			</ul>
+		<li>You can also specify precedence by using parentheses, but using phrases inside them might lead to unexpected results.</li>
+	</ul>
 </div>
 
 {{ linkable_header("Reporting Torrents", "reporting") }}
@@ -72,18 +67,9 @@
 <div>
 	You can style your comments and your torrent's description using
 	<a href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet">Markdown</a>.
-	This includes adding images or linking to external websites.
-</div>
-<div>
-	To link to an external site, use <kbd>[label](https://example.com)</kbd>
-	where the text in the <kbd>[]</kbd> square brackets is the shown text of your
-	link, and the URL in the <kbd>()</kbd> parentheses is the URL your link will
-	point to.
-</div>
-<div>
-	Embedding an image is similar. Use <kbd>![alt text](https://example.com/image.jpg)</kbd>
-	to have an image embedded in your comment or description. Note the <kbd>!</kbd>
-	exclamation mark at the beginning, denoting that this link is an image.
+	<li>To embed a link, use <kbd>[label](https://example.com)</kbd></li>
+	<li>You can embed an image similarly using <kbd>![label](https://example.com/image.jpg)</kbd></li>
+	<li>To make text italic or bold, use <kbd>*</kbd> or <kbd>**</kbd> surround it, respectively</li>
 </div>
 
 {{ linkable_header("Changing Your User's Avatar", "avatar") }}


### PR DESCRIPTION
There was a grammar mistake in the beginning of the help page(line 17) that I couldn't stand, so I fixed it!

Also, I reformatted the searching instructions so that it's more organized and easy-to-understand. 