### PR TITLE
Add 1 hour cache to magnet URIs

### DIFF
--- a/nyaa/__init__.py
+++ b/nyaa/__init__.py
@@ -6,7 +6,7 @@ import flask
 from flask_assets import Bundle  # noqa F401
 
 from nyaa.api_handler import api_blueprint
-from nyaa.extensions import assets, db, fix_paginate, toolbar
+from nyaa.extensions import assets, cache, db, fix_paginate, toolbar
 from nyaa.template_utils import bp as template_utils_bp
 from nyaa.utils import random_string
 from nyaa.views import register_views
@@ -101,5 +101,8 @@ def create_app(config):
         with app.app_context():
             url = flask.url_for('static', filename='img/avatar/default.png', _external=True)
             app.config['DEFAULT_GRAVATAR_URL'] = url
+
+    # Cache
+    cache.init_app(app)
 
     return app

--- a/nyaa/extensions.py
+++ b/nyaa/extensions.py
@@ -3,12 +3,14 @@ import os.path
 from flask import abort
 from flask.config import Config
 from flask_assets import Environment
+from flask_caching import Cache
 from flask_debugtoolbar import DebugToolbarExtension
 from flask_sqlalchemy import BaseQuery, Pagination, SQLAlchemy
 
 assets = Environment()
 db = SQLAlchemy()
 toolbar = DebugToolbarExtension()
+cache = Cache(config={'CACHE_TYPE': 'simple'})
 
 
 def fix_paginate():

--- a/nyaa/models.py
+++ b/nyaa/models.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext import declarative
 from sqlalchemy_fulltext import FullText
 from sqlalchemy_utils import ChoiceType, EmailType, PasswordType
 
-from nyaa.extensions import config, db
+from nyaa.extensions import cache, config, db
 from nyaa.torrents import create_magnet
 
 app = flask.current_app
@@ -243,6 +243,7 @@ class TorrentBase(DeclarativeHelperBase):
         return self.info_hash.hex()
 
     @property
+    @cache.memoize(timeout=3600)
     def magnet_uri(self):
         return create_magnet(self)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,3 +53,4 @@ visitor==0.1.3
 webassets==0.12.1
 Werkzeug==0.12.2
 WTForms==2.1
+Flask-Caching==1.4.0


### PR DESCRIPTION
Using Flask-Caching, we can memoize the `magnet_uri` method. Here, a timeout of 1 hour is chosen, though that value can be fiddled with.

The cache is defined in `extensions.py`, but gets initialised in `__init__.py`.