### PR TITLE
Make blue info bubble dismissible, configurable

### DIFF
--- a/nyaa/static/js/main.js
+++ b/nyaa/static/js/main.js
@@ -260,6 +260,16 @@ document.addEventListener("DOMContentLoaded", function() {
 	}
 });
 
+// Info bubble stuff
+document.addEventListener("DOMContentLoaded", function() {
+	var bubble = document.getElementById('infobubble');
+	if (Number(localStorage.getItem('infobubble_dismiss_ts')) < Number(bubble.dataset.ts)) {
+		bubble.removeAttribute('hidden');
+	}
+	$('#infobubble').on('close.bs.alert', function () {
+		localStorage.setItem('infobubble_dismiss_ts', bubble.dataset.ts);
+	})
+});
 
 // Decode HTML entities (&gt; etc), used for decoding comment markdown from escaped text
 function htmlDecode(input){

--- a/nyaa/templates/home.html
+++ b/nyaa/templates/home.html
@@ -12,10 +12,7 @@
 {% block body %}
 
 {% if not search.term %}
-<div class="alert alert-info">
-	<p>We welcome you to provide feedback on IRC at <a href="irc://irc.rizon.net/nyaa-dev">#nyaa-dev@irc.rizon.net</a></p>
-	<p>Our GitHub: <a href="https://github.com/nyaadevs" target="_blank">https://github.com/nyaadevs</a> - creating <a href="https://github.com/nyaadevs/nyaa/issues">issues</a> for features and faults is recommended!</p>
-</div>
+{% include "infobubble.html" %}
 {% endif %}
 
 {% include "search_results.html" %}

--- a/nyaa/templates/infobubble.html
+++ b/nyaa/templates/infobubble.html
@@ -1,0 +1,14 @@
+{% import "infobubble_content.html" as info %}
+{% if info.info_text %}
+<div class="alert alert-info alert-dismissible" id="infobubble" data-ts='{{ info.info_ts }}' hidden>
+	{{ info.info_text|safe }}
+	<button type="button" class="close" data-dismiss="alert" aria-label="Close">
+		<span aria-hidden="true">&times;</span>
+	</button>
+</div>
+<noscript>
+<div class="alert alert-info" id="infobubble-noscript">
+	{{ info.info_text|safe }}
+</div>
+</noscript>
+{% endif %}

--- a/nyaa/templates/infobubble_content.html
+++ b/nyaa/templates/infobubble_content.html
@@ -1,0 +1,3 @@
+{% set info_text = "<b>Put your announcements here!</b>" %}
+{# Update this to a larger timestamp if you change your announcement #}
+{% set info_ts = 1531215917 %}


### PR DESCRIPTION
Infobubble text is now in a separate file, along with a timestamp, so that changes to it don't result in merge conflicts too often.

We also add some JS to make the bubble dismissible, keeping track of the last timestamp that was dismissed in localstorage.

I'm not entirely sure if I'm happy with the "HTML inside template variable" approach. If someone has a better idea, let me know. This is a bit of a ghetto setup until we have an announcement blog or something that does this in the database.