### PR TITLE
[Config change] Allow blacklisting email servers by IP

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -59,6 +59,11 @@ EMAIL_BLACKLIST = (
     re.compile(r'(?i)@(msn\.com|passport\.(com|net))'),
     # '@dodgydomain.tk'
 )
+EMAIL_SERVER_BLACKLIST = (
+    # Bad mailserver IPs here (MX server.com -> A mail.server.com > 11.22.33.44)
+    # '1.2.3.4', '11.22.33.44'
+)
+
 
 
 # Recaptcha keys (https://www.google.com/recaptcha)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ blinker==1.4
 cffi==1.10.0
 click==6.7
 dominate==2.3.1
+dnspython==1.15.0
 elasticsearch==5.3.0
 elasticsearch-dsl==5.2.0
 flake8==3.3.0


### PR DESCRIPTION
```
Adds a new config entry (EMAIL_SERVER_BLACKLIST, tuple of IPv4 addresses
as strings) and an email validator for registering, which will query all
the MX records for the domain and reject the registration if any of the
A records for any of the MX records are found in the blacklist.
If the query fails, the blacklist is ignored; the email is accepted.
```

This also adds `dnspython` as a requirement; run `pip install -r requirements.txt`