### PR TITLE
Tiny patch to prevent open redirect vunerability.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 __pycache__
 /nyaa/static/.webassets-cache
 
+# Byte Code
+*.pyc
+
 # Virtual Environments
 /venv
 

--- a/nyaa/views/account.py
+++ b/nyaa/views/account.py
@@ -217,7 +217,7 @@ def redirect_url():
         flask.request.referrer or \
         home_url
 
-    if url == flask.request.url or not flask.request.host in url:
+    if url == flask.request.url or flask.request.host not in url:
         return home_url
 
     return url

--- a/nyaa/views/account.py
+++ b/nyaa/views/account.py
@@ -216,8 +216,10 @@ def redirect_url():
     url = flask.request.args.get('next') or \
         flask.request.referrer or \
         home_url
-    if url == flask.request.url:
+
+    if url == flask.request.url or not flask.request.host in url:
         return home_url
+
     return url
 
 


### PR DESCRIPTION
Fixed the issue mentioned in #519 by adding a check that only allows redirects for URL with host name, if ```?next=``` URL does not contain host, it will redirect to ```main.home```. 