### PR TITLE
Make blue info bubble dismissible, configurable (second attempt)

### DIFF
--- a/nyaa/static/js/main.js
+++ b/nyaa/static/js/main.js
@@ -260,6 +260,16 @@ document.addEventListener("DOMContentLoaded", function() {
 	}
 });
 
+// Info bubble stuff
+document.addEventListener("DOMContentLoaded", function() {
+	var bubble = document.getElementById('infobubble');
+	if (Number(localStorage.getItem('infobubble_dismiss_ts')) < Number(bubble.dataset.ts)) {
+		bubble.removeAttribute('hidden');
+	}
+	$('#infobubble').on('close.bs.alert', function () {
+		localStorage.setItem('infobubble_dismiss_ts', bubble.dataset.ts);
+	})
+});
 
 // Decode HTML entities (&gt; etc), used for decoding comment markdown from escaped text
 function htmlDecode(input){

--- a/nyaa/templates/home.html
+++ b/nyaa/templates/home.html
@@ -12,10 +12,7 @@
 {% block body %}
 
 {% if not search.term %}
-<div class="alert alert-info">
-	<p>We welcome you to provide feedback on IRC at <a href="irc://irc.rizon.net/nyaa-dev">#nyaa-dev@irc.rizon.net</a></p>
-	<p>Our GitHub: <a href="https://github.com/nyaadevs" target="_blank">https://github.com/nyaadevs</a> - creating <a href="https://github.com/nyaadevs/nyaa/issues">issues</a> for features and faults is recommended!</p>
-</div>
+{% include "infobubble.html" %}
 {% endif %}
 
 {% include "search_results.html" %}

--- a/nyaa/templates/infobubble.html
+++ b/nyaa/templates/infobubble.html
@@ -1,0 +1,16 @@
+{# Update this to a larger timestamp if you change your announcement #}
+{# A value of 0 disables the announcements altogether #}
+{% set info_ts = 0 %}
+{% if info_ts > 0 %}
+<div class="alert alert-info alert-dismissible" id="infobubble" data-ts='{{ info_ts }}' hidden>
+	{% include 'infobubble_content.html' %}
+	<button type="button" class="close" data-dismiss="alert" aria-label="Close">
+		<span aria-hidden="true">&times;</span>
+	</button>
+</div>
+<noscript>
+<div class="alert alert-info" id="infobubble-noscript">
+	{% include 'infobubble_content.html' %}
+</div>
+</noscript>
+{% endif %}

--- a/nyaa/templates/infobubble_content.html
+++ b/nyaa/templates/infobubble_content.html
@@ -1,0 +1,1 @@
+<strong>Put your announcements into <tt>infobubble_content.html</tt>!</strong>


### PR DESCRIPTION
Changes from last time:

1. `infobubble_content.html` still is a separate file, but now instead of containing variables, contains just an actual HTML template.
2. `info_ts` is now in the main infobubble ts file because otherwise our include wouldn't work.
3. Use include now so we don't have to have users duplicate their message for non-JS users.
4. Setting `info_ts` to 0 disables the bubble now.

I've rebased it onto master too, because I'm a good lad.