### PR TITLE
Add comments listing for moderators

### DIFF
--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -108,6 +108,7 @@
 								<li {% if request.path == url_for('admin.reports') %}class="active"{% endif %}><a href="{{ url_for('admin.reports') }}">Reports</a></li>
 								<li {% if request.path == url_for('admin.log') %}class="active"{% endif %}><a href="{{ url_for('admin.log') }}">Log</a></li>
 								<li {% if request.path == url_for('admin.bans') %}class="active"{% endif %}><a href="{{ url_for('admin.bans') }}">Bans</a></li>
+								<li {% if request.path == url_for('admin.comments') %}class="active"{% endif %}><a href="{{ url_for('admin.comments') }}">Comments</a></li>
 							</ul>
 						</li>
 						{% endif %}

--- a/nyaa/views/admin.py
+++ b/nyaa/views/admin.py
@@ -114,3 +114,23 @@ def view_reports():
     return flask.render_template('reports.html',
                                  reports=reports,
                                  report_action=report_action)
+
+
+@bp.route('/comments', endpoint='comments', methods=['GET'])
+def view_comments():
+    if not flask.g.user or not flask.g.user.is_moderator:
+        flask.abort(403)
+
+    page_number = flask.request.args.get('p')
+    try:
+        page_number = max(1, int(page_number))
+    except (ValueError, TypeError):
+        page_number = 1
+
+    comments_per_page = 50
+
+    comments_query = (models.Comment.query.filter()
+                                          .order_by(models.Comment.created_time.desc()))
+    comments_query = comments_query.paginate_faste(page_number, per_page=comments_per_page, step=5)
+    return flask.render_template('comments.html',
+                                 comments_query=comments_query)


### PR DESCRIPTION
Implements a moderation tool that lists all comments (as mentioned by @CounterPillow in comments of #366), similarily to per-user list that's already available. I set it to show 50 comments per page, so it doesn't take too long to load in case there are a lot of long comments.
