### PR TITLE
Tweaks for "Complete" torrents

### DIFF
--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -237,7 +237,7 @@
 								<option value="0" title="No filter" {% if search is defined and search["quality_filter"] == "0" %}selected{% else %}selected{% endif %}>No filter</option>
 								<option value="1" title="No remakes" {% if search is defined and search["quality_filter"] == "1" %}selected{% endif %}>No remakes</option>
 								<option value="2" title="Trusted only" {% if search is defined and search["quality_filter"] == "2" %}selected{% endif %}>Trusted only</option>
-								<option value="3" title="Completed only" {% if search is defined and search["quality_filter"] == "3" %}selected{% endif %}>Completed only</option>
+								<option value="3" title="Complete only" {% if search is defined and search["quality_filter"] == "3" %}selected{% endif %}>Complete only</option>
 							</select>
 
 							<br>
@@ -272,7 +272,7 @@
 									<option value="0" title="No filter" {% if search is defined and search["quality_filter"] == "0" %}selected{% else %}selected{% endif %}>No filter</option>
 									<option value="1" title="No remakes" {% if search is defined and search["quality_filter"] == "1" %}selected{% endif %}>No remakes</option>
 									<option value="2" title="Trusted only" {% if search is defined and search["quality_filter"] == "2" %}selected{% endif %}>Trusted only</option>
-									<option value="3" title="Completed only" {% if search is defined and search["quality_filter"] == "3" %}selected{% endif %}>Completed only</option>
+									<option value="3" title="Complete only" {% if search is defined and search["quality_filter"] == "3" %}selected{% endif %}>Complete only</option>
 								</select>
 							</div>
 

--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -237,6 +237,7 @@
 								<option value="0" title="No filter" {% if search is defined and search["quality_filter"] == "0" %}selected{% else %}selected{% endif %}>No filter</option>
 								<option value="1" title="No remakes" {% if search is defined and search["quality_filter"] == "1" %}selected{% endif %}>No remakes</option>
 								<option value="2" title="Trusted only" {% if search is defined and search["quality_filter"] == "2" %}selected{% endif %}>Trusted only</option>
+								<option value="3" title="Completed only" {% if search is defined and search["quality_filter"] == "3" %}selected{% endif %}>Completed only</option>
 							</select>
 
 							<br>
@@ -271,6 +272,7 @@
 									<option value="0" title="No filter" {% if search is defined and search["quality_filter"] == "0" %}selected{% else %}selected{% endif %}>No filter</option>
 									<option value="1" title="No remakes" {% if search is defined and search["quality_filter"] == "1" %}selected{% endif %}>No remakes</option>
 									<option value="2" title="Trusted only" {% if search is defined and search["quality_filter"] == "2" %}selected{% endif %}>Trusted only</option>
+									<option value="3" title="Completed only" {% if search is defined and search["quality_filter"] == "3" %}selected{% endif %}>Completed only</option>
 								</select>
 							</div>
 

--- a/nyaa/templates/search_results.html
+++ b/nyaa/templates/search_results.html
@@ -31,6 +31,8 @@
 				{% call render_column_header("hdr-comments", "width:50px;", center_text=True, sort_key="comments", header_title="Comments") %}
 					<i class="fa fa-comments-o"></i>
 				{% endcall %}
+				{% call render_column_header("hdr-complete", "width:5px;", center_text=True) %}
+				{% endcall %}				
 				{% call render_column_header("hdr-link", "width:70px;", center_text=True) %}
 					<div>Link</div>
 				{% endcall %}
@@ -82,6 +84,9 @@
 					{% else %}
 					<a href="{{ url_for('torrents.view', torrent_id=torrent_id) }}" title="{{ torrent.display_name | escape }}">{{ torrent.display_name | escape }}</a>
 					{% endif %}
+				</td>
+				<td class="text-center" style="white-space: nowrap;">
+					{% if torrent.complete %} <span class='label label-warning' title='Complete'>C</span>{% endif %}
 				</td>
 				<td class="text-center" style="white-space: nowrap;">
 					{% if torrent.has_torrent %}<a href="{{ url_for('torrents.download', torrent_id=torrent_id) }}"><i class="fa fa-fw fa-download"></i></a>{% endif %}


### PR DESCRIPTION
Currently, "Complete" option has basically no effect. You can search for complete only, but this option is hidden and unknown.

This PR adds "Complete only" to dropdown + a marker for torrents marked as complete. I don't have any better idea where to put that marker, but I think a separate row is the best. It also allows for later addition of more fields, which can be used with trusted/remake eg. trusted+remaster.

[Here](https://cdn.discordapp.com/attachments/191116708990287872/506935143529971740/unknown.png)'s an example of how it looks.

Even if you decide to not merge this layout change with a new row, I believe it's worth adding a "Complete only" option to dropdown to encourage people to use it.