### PR TITLE
Remove leechers-paradise from default trackers

### DIFF
--- a/trackers.txt
+++ b/trackers.txt
@@ -4,4 +4,4 @@
 udp://open.stealth.si:80/announce
 udp://tracker.opentrackr.org:1337/announce
 udp://tracker.coppersurfer.tk:6969/announce
-udp://tracker.leechers-paradise.org:6969/announce
+udp://exodus.desync.com:6969/announce


### PR DESCRIPTION
Leechers Paradise shut down yesterday: https://torrentfreak.com/huge-torrent-tracker-calls-it-quits-after-12-years-citing-article-13-181207/

No point continuing to add it to torrents.