### PR TITLE
templates: move icon_dir set outside of the loop

### DIFF
--- a/nyaa/templates/search_results.html
+++ b/nyaa/templates/search_results.html
@@ -55,11 +55,11 @@
 			</tr>
 		</thead>
 		<tbody>
+			{% set icon_dir = config.SITE_FLAVOR %}
 			{% set torrents = torrent_query if use_elastic else torrent_query.items %}
 			{% for torrent in torrents %}
 			<tr class="{% if torrent.deleted %}deleted{% elif torrent.hidden %}warning{% elif torrent.remake %}danger{% elif torrent.trusted %}success{% else %}default{% endif %}">
 				{% set cat_id = use_elastic and ((torrent.main_category_id|string) + '_' + (torrent.sub_category_id|string)) or torrent.sub_category.id_as_string %}
-				{% set icon_dir = config.SITE_FLAVOR %}
 				<td style="padding:0 4px;">
 				{% if use_elastic %}
 				<a href="{{ url_for('main.home', c=cat_id) }}" title="{{ category_name(cat_id) }}">


### PR DESCRIPTION
Someone put this inside the loop despite it essentially being constant. Probably makes immeasurably little difference perf-wise, but why not fix it anyway.