### PR TITLE
templates: cache torrent view filelist

### DIFF
--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -93,7 +93,7 @@
 	</div>
 </div>
 
-{% cache 3600, "filelist", torrent.info_hash_as_hex %}
+{% cache 86400, "filelist", torrent.info_hash_as_hex %}
 {% if files and files.__len__() <= config.MAX_FILES_VIEW %}
 <div class="panel panel-default">
 	<div class="panel-heading">

--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -93,6 +93,7 @@
 	</div>
 </div>
 
+{% cache 3600, "filelist", torrent.info_hash_as_hex %}
 {% if files and files.__len__() <= config.MAX_FILES_VIEW %}
 <div class="panel panel-default">
 	<div class="panel-heading">
@@ -133,6 +134,7 @@
 	</div>
 </div>
 {% endif %}
+{% endcache %}
 
 <div id="comments" class="panel panel-default">
 	<div class="panel-heading">


### PR DESCRIPTION
Using flask-caching, we can add a 1 hour cache to the template output of a filelist, varying it by the key "filelist" + the hex infohash of a torrent.

Using a very big filelist as a test, I get a difference in page load speeds of about a magnitude. (400ms -> 37 ms)