### PR TITLE
upload/edit: sanitize some string fields

### DIFF
--- a/nyaa/views/torrents.py
+++ b/nyaa/views/torrents.py
@@ -106,9 +106,9 @@ def edit_torrent(torrent_id):
         # Form has been sent, edit torrent with data.
         torrent.main_category_id, torrent.sub_category_id = \
             form.category.parsed_data.get_category_ids()
-        torrent.display_name = (form.display_name.data or '').strip()
-        torrent.information = (form.information.data or '').strip()
-        torrent.description = (form.description.data or '').strip()
+        torrent.display_name = backend.sanitize_string((form.display_name.data or '').strip())
+        torrent.information = backend.sanitize_string((form.information.data or '').strip())
+        torrent.description = backend.sanitize_string((form.description.data or '').strip())
 
         torrent.hidden = form.is_hidden.data
         torrent.remake = form.is_remake.data

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -37,6 +37,16 @@ class TestBackend(unittest.TestCase):
         self.assertTrue(backend._replace_utf8_values(test_dict))
         self.assertDictEqual(test_dict, expected_dict)
 
+    def test_replace_invalid_xml_chars(self):
+        self.assertEqual(backend.sanitize_string('ayy\x08lmao'), 'ayy\uFFFDlmao')
+        self.assertEqual(backend.sanitize_string('ayy\x0clmao'), 'ayy\uFFFDlmao')
+        self.assertEqual(backend.sanitize_string('ayy\uD8FFlmao'), 'ayy\uFFFDlmao')
+        self.assertEqual(backend.sanitize_string('ayy\uFFFElmao'), 'ayy\uFFFDlmao')
+        self.assertEqual(backend.sanitize_string('\x08ayy\x0clmao'), '\uFFFDayy\uFFFDlmao')
+        self.assertEqual(backend.sanitize_string('ayy\x08\x0clmao'), 'ayy\uFFFD\uFFFDlmao')
+        self.assertEqual(backend.sanitize_string('ayy\x08\x08lmao'), 'ayy\uFFFD\uFFFDlmao')
+        self.assertEqual(backend.sanitize_string('ぼくのぴこ'), 'ぼくのぴこ')
+
     @unittest.skip('Not yet implemented')
     def test_handle_torrent_upload(self):
         pass


### PR DESCRIPTION
This commit introduces a regex to replace illegal (expectedly unused)
characters from torrent display name, information link and description
upon upload or edit.

Fixes #541

No automatic cleanup for existing possibly dirty fields, though that's easy enough to do by hand.