### PR TITLE
view: fix template throwing exception on edge case

### DIFF
--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -175,7 +175,7 @@
 				<div class="row">
 					{# Escape newlines into html entities because CF strips blank newlines #}
 					<div markdown-text class="comment-content" id="torrent-comment{{ comment.id }}">{{- comment.text | escape | replace('\r\n', '\n') | replace('\n', '&#10;'|safe) -}}</div>
-					{% if g.user.id == comment.user_id %}
+					{% if g.user.id == comment.user_id and comment_form %}
 					<form class="edit-comment-box" action="{{ url_for('torrents.edit_comment', torrent_id=torrent.id, comment_id=comment.id) }}" method="POST">
 						{{ comment_form.csrf_token }}
 						<div class="form-group">


### PR DESCRIPTION
If a user has a comment under the edit time limit in a comment locked torrent, but also are still affected by the new account CAPTCHA cooldown, the template would throw an error as we tried to getattr on a None object (namely, the `comment_form`).

To fix this, we also need to check around the edit form whether the `comment_form` exists.