### PR TITLE
account: force ASCII usernames on login form

### DIFF
--- a/nyaa/views/account.py
+++ b/nyaa/views/account.py
@@ -26,6 +26,9 @@ def login():
             return flask.redirect(flask.url_for('account.login'))
 
         username = form.username.data.strip()
+        if not username.isascii():
+            flask.flash('Invalid characters in username.', 'danger')
+            return flask.redirect(flask.url_for('account.login'))
         password = form.password.data
         user = models.User.by_username(username)
 


### PR DESCRIPTION
Our database doesn't like it when we check for unicode data in a column that stores ASCII data, so let's stop it before it gets that far.