### PR TITLE
view.html: fix comment text copypasting in Firefox

### DIFF
--- a/nyaa/static/css/main.css
+++ b/nyaa/static/css/main.css
@@ -275,6 +275,11 @@ a.text-purple:hover, a.text-purple:active, a.text-purple:focus {
 	margin-bottom: 10px;
 }
 
+/* workaround for Mozilla whitespace copypaste dumbfuckery */
+.comment-body {
+	-moz-user-select: text;
+}
+
 .comment-content {
 	overflow-wrap: break-word;
 }

--- a/nyaa/templates/view.html
+++ b/nyaa/templates/view.html
@@ -174,7 +174,7 @@
 						{% endif %}
 					</div>
 				</div>
-				<div class="row">
+				<div class="row comment-body">
 					{# Escape newlines into html entities because CF strips blank newlines #}
 					<div markdown-text class="comment-content" id="torrent-comment{{ comment.id }}">{{- comment.text | escape | replace('\r\n', '\n') | replace('\n', '&#10;'|safe) -}}</div>
 					{% if g.user.id == comment.user_id and comment_form %}


### PR DESCRIPTION
Firefox would insert a lot of weird whitespace, because its `user-select` would default to `all` and not `text`, so it copypastes the whitespace of otherwise completely invisible HTML elements.

I don't know why Firefox does this. It's stupid, and not what the user expects. They're copying what they see, not what the DOM is.