### PR TITLE
Improve cache configuration

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -188,3 +188,20 @@ TRUSTED_MIN_UPLOADS = 10
 TRUSTED_MIN_DOWNLOADS = 10000
 # Number of days an applicant needs to wait before re-applying
 TRUSTED_REAPPLY_COOLDOWN = 90
+
+###########
+## Cache ##
+###########
+
+# Interesting types include "simple", "redis" and "uwsgi"
+# See https://pythonhosted.org/Flask-Caching/#configuring-flask-caching
+CACHE_TYPE = "simple"
+
+# Maximum number of items the cache will store
+# Only applies to "simple" and "filesystem" cache types
+CACHE_THRESHOLD = 8192
+
+# If you want to use redis, try this
+# CACHE_TYPE = "redis"
+# CACHE_REDIS_HOST = "127.0.0.1"
+# CACHE_KEY_PREFIX = "catcache_"

--- a/nyaa/__init__.py
+++ b/nyaa/__init__.py
@@ -126,6 +126,6 @@ def create_app(config):
             app.config['DEFAULT_GRAVATAR_URL'] = url
 
     # Cache
-    cache.init_app(app)
+    cache.init_app(app, config=app.config)
 
     return app

--- a/nyaa/extensions.py
+++ b/nyaa/extensions.py
@@ -10,7 +10,7 @@ from flask_sqlalchemy import BaseQuery, Pagination, SQLAlchemy
 assets = Environment()
 db = SQLAlchemy()
 toolbar = DebugToolbarExtension()
-cache = Cache(config={'CACHE_TYPE': 'simple'})
+cache = Cache()
 
 
 class LimitedPagination(Pagination):

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,7 @@ SQLAlchemy-Utils==0.34.1
 statsd==3.3.0
 urllib3==1.25.3
 uWSGI==2.0.18
+redis==3.2.1
 webassets==0.12.1
 Werkzeug==0.15.5
 WTForms==2.2.1


### PR DESCRIPTION
The Flask-Caching cache can now properly be configured from the config.py, and redis caching has experimentally been tested and confirmed to be working in theory.

We also document that one may want to use CACHE_THRESHOLD to limit the maximum number of items in the simple cache.