### PR TITLE
backend: count IP uploads in the user ratelimit

### DIFF
--- a/nyaa/backend.py
+++ b/nyaa/backend.py
@@ -139,7 +139,9 @@ def check_uploader_ratelimit(user):
 
     def filter_uploader(query):
         if user:
-            return query.filter(Torrent.user == user)
+            return query.filter(sqlalchemy.or_(
+                Torrent.user == user,
+                Torrent.uploader_ip == ip_address(flask.request.remote_addr).packed))
         else:
             return query.filter(Torrent.uploader_ip == ip_address(flask.request.remote_addr).packed)
 


### PR DESCRIPTION
Users could double their ratelimit by uploading some torrents as anonymous submissions, then log into their account and post more.

We can stop this by making the filter_uploader helper function use an sqlalchemy.or_ query to check for uploads from either that user or that user's IP.