### PR TITLE
Follow Google's example for less offensive code

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -58,10 +58,10 @@ ALLOW_PASSWORD_RESET = True
 # A list of strings or compiled regexes to deny registering emails by.
 # Regexes will be .search()'d against emails,
 # while strings will be a simple 'string in email.lower()' check.
-# Leave empty to disable the blacklist.
-EMAIL_BLACKLIST = (
+# Leave empty to disable the gamerlist.
+EMAIL_GAMERLIST = (
     # Hotmail completely rejects "untrusted" emails,
-    # so it's less of a headache to blacklist them as users can't receive the mails anyway.
+    # so it's less of a headache to gamerlist them as users can't receive the mails anyway.
     # (Hopefully) complete list of Microsoft email domains follows:
     re.compile(r'(?i)@hotmail\.(co|co\.uk|com|de|dk|eu|fr|it|net|org|se)'),
     re.compile(r'(?i)@live\.(co|co.uk|com|de|dk|eu|fr|it|net|org|se|no)'),
@@ -69,7 +69,7 @@ EMAIL_BLACKLIST = (
     re.compile(r'(?i)@(msn\.com|passport\.(com|net))'),
     # '@dodgydomain.tk'
 )
-EMAIL_SERVER_BLACKLIST = (
+EMAIL_SERVER_GAMERLIST = (
     # Bad mailserver IPs here (MX server.com -> A mail.server.com > 11.22.33.44)
     # '1.2.3.4', '11.22.33.44'
 )

--- a/nyaa/backend.py
+++ b/nyaa/backend.py
@@ -15,12 +15,12 @@ from nyaa.extensions import db
 
 app = flask.current_app
 
-# Blacklists for _validate_torrent_filenames
+# Gamerlists for _validate_torrent_filenames
 # TODO: consider moving to config.py?
-CHARACTER_BLACKLIST = [
+CHARACTER_GAMERLIST = [
     '\u202E',  # RIGHT-TO-LEFT OVERRIDE
 ]
-FILENAME_BLACKLIST = [
+FILENAME_GAMERLIST = [
     # Windows reserved filenames
     'con',
     'nul',
@@ -86,14 +86,14 @@ def _recursive_dict_iterator(source):
 
 
 def _validate_torrent_filenames(torrent):
-    ''' Checks path parts of a torrent's filetree against blacklisted characters
+    ''' Checks path parts of a torrent's filetree against gamerlisted characters
         and filenames, returning False on rejection '''
     file_tree = json.loads(torrent.filelist.filelist_blob.decode('utf-8'))
 
     for path_part, value in _recursive_dict_iterator(file_tree):
-        if path_part.rsplit('.', 1)[0].lower() in FILENAME_BLACKLIST:
+        if path_part.rsplit('.', 1)[0].lower() in FILENAME_GAMERLIST:
             return False
-        if any(True for c in CHARACTER_BLACKLIST if c in path_part):
+        if any(True for c in CHARACTER_GAMERLIST if c in path_part):
             return False
 
     return True

--- a/nyaa/forms.py
+++ b/nyaa/forms.py
@@ -73,12 +73,12 @@ def upload_recaptcha_validator_shim(form, field):
         return True
 
 
-def register_email_blacklist_validator(form, field):
-    email_blacklist = app.config.get('EMAIL_BLACKLIST', [])
+def register_email_gamerlist_validator(form, field):
+    email_gamerlist = app.config.get('EMAIL_GAMERLIST', [])
     email = field.data.strip()
-    validation_exception = StopValidation('Blacklisted email provider')
+    validation_exception = StopValidation('Gamerlisted email provider')
 
-    for item in email_blacklist:
+    for item in email_gamerlist:
         if isinstance(item, re.Pattern):
             if item.search(email):
                 raise validation_exception
@@ -91,11 +91,11 @@ def register_email_blacklist_validator(form, field):
 
 
 def register_email_server_validator(form, field):
-    server_blacklist = app.config.get('EMAIL_SERVER_BLACKLIST', [])
-    if not server_blacklist:
+    server_gamerlist = app.config.get('EMAIL_SERVER_GAMERLIST', [])
+    if not server_gamerlist:
         return True
 
-    validation_exception = StopValidation('Blacklisted email provider')
+    validation_exception = StopValidation('Gamerlisted email provider')
     email = field.data.strip()
     email_domain = email.split('@', 1)[-1]
 
@@ -113,9 +113,9 @@ def register_email_server_validator(form, field):
             # Query mailserver A records
             a_records = list(dns.resolver.query(mx_record.exchange))
             for a_record in a_records:
-                # Check for address in blacklist
-                if a_record.address in server_blacklist:
-                    app.logger.warning('Rejected email %s due to blacklisted mailserver (%s, %s)',
+                # Check for address in gamerlist
+                if a_record.address in server_gamerlist:
+                    app.logger.warning('Rejected email %s due to gamerlisted mailserver (%s, %s)',
                                        email, a_record.address, mx_record.exchange)
                     raise validation_exception
 
@@ -169,7 +169,7 @@ class RegisterForm(FlaskForm):
         Email(),
         DataRequired(),
         Length(min=5, max=128),
-        register_email_blacklist_validator,
+        register_email_gamerlist_validator,
         Unique(User, User.email, 'Email already in use by another account'),
         register_email_server_validator
     ])


### PR DESCRIPTION
Through an etymological misinterpretation arising from being paid $9999999 a year to find racism where there is none, [the finest 10x engineers at Google][1] have determined that the terms "bl\*cklist" and "wh\*telist" are offensive, no doubt while sipping a latte in a gentrified neighbourhood café.

Therefore, we should replace the term "black" with a word that is universally acknowledged to have negative connotations, namely "gamer".

[1]: https://chromium.googlesource.com/chromium/src.git/+/a9d6aa6ffdfea124df722090104e0e491d6bf071%5E%21/

:^)