### PR TITLE
Introduce baked queries

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -156,6 +156,13 @@ RESULTS_PER_PAGE = 75
 # How many pages we'll return at most
 MAX_PAGES = 100
 
+# How long and how many entries to cache for count queries
+COUNT_CACHE_SIZE = 256
+COUNT_CACHE_DURATION = 30
+
+# Use baked queries for database search
+USE_BAKED_SEARCH = False
+
 # Use better searching with ElasticSearch
 # See README.MD on setup!
 USE_ELASTIC_SEARCH = False

--- a/nyaa/views/main.py
+++ b/nyaa/views/main.py
@@ -10,7 +10,7 @@ from flask_paginate import Pagination
 from nyaa import models
 from nyaa.extensions import db
 from nyaa.search import (DEFAULT_MAX_SEARCH_RESULT, DEFAULT_PER_PAGE, SERACH_PAGINATE_DISPLAY_MSG,
-                         _generate_query_string, search_db, search_elastic)
+                         _generate_query_string, search_db, search_db_baked, search_elastic)
 from nyaa.utils import chain_get
 from nyaa.views.account import logout
 
@@ -186,7 +186,11 @@ def home(rss):
         else:  # Otherwise, use db search for everything
             query_args['term'] = search_term or ''
 
-        query = search_db(**query_args)
+        if app.config['USE_BAKED_SEARCH']:
+            query = search_db_baked(**query_args)
+        else:
+            query = search_db(**query_args)
+
         if render_as_rss:
             return render_rss('Home', query, use_elastic=False, magnet_links=use_magnet_links)
         else:

--- a/nyaa/views/users.py
+++ b/nyaa/views/users.py
@@ -12,7 +12,7 @@ from itsdangerous import BadSignature, URLSafeSerializer
 from nyaa import forms, models
 from nyaa.extensions import db
 from nyaa.search import (DEFAULT_MAX_SEARCH_RESULT, DEFAULT_PER_PAGE, SERACH_PAGINATE_DISPLAY_MSG,
-                         _generate_query_string, search_db, search_elastic)
+                         _generate_query_string, search_db, search_db_baked, search_elastic)
 from nyaa.utils import admin_only, chain_get, sha1_hash
 
 app = flask.current_app
@@ -185,7 +185,10 @@ def view_user(user_name):
             query_args['term'] = ''
         else:
             query_args['term'] = search_term or ''
-        query = search_db(**query_args)
+        if app.config['USE_BAKED_SEARCH']:
+            query = search_db_baked(**query_args)
+        else:
+            query = search_db(**query_args)
         return flask.render_template('user.html',
                                      use_elastic=False,
                                      torrent_query=query,


### PR DESCRIPTION
```
SQA's baked queries prepares the queries in advance, caching yada yada.
Makes thing a bit faster.
Also bigger speedup included is a shoddy cache for the total torrent
count (only applied to baked queries currently). Caching the value for a
few dozen seconds shaves off some wasted time, as it's mostly just used
for pagination.
```

Yeah yeah, get baked, ha ha.

Simple benchmarks
```
Before baked
Page   1: min: 59.0ms max: 72.9ms avg: 67.1ms
Page   2: min: 56.2ms max: 97.6ms avg: 66.1ms
Page   3: min: 60.1ms max: 92.4ms avg: 69.3ms
Page   4: min: 59.9ms max: 88.0ms avg: 68.8ms
Page   5: min: 60.1ms max: 90.9ms avg: 67.1ms

With baked (no count cache, COUNT_CACHE_DURATION=0)
Page   1: min: 56.6ms max: 69.2ms avg: 61.8ms
Page   2: min: 51.0ms max: 75.5ms avg: 62.1ms
Page   3: min: 52.8ms max: 76.5ms avg: 59.9ms
Page   4: min: 49.4ms max: 75.8ms avg: 59.9ms
Page   5: min: 53.9ms max: 89.0ms avg: 63.3ms

With baked and count cache
Page   1: min: 37.8ms max: 52.0ms avg: 43.9ms
Page   2: min: 38.8ms max: 65.7ms avg: 45.4ms
Page   3: min: 39.4ms max: 72.3ms avg: 45.7ms
Page   4: min: 40.7ms max: 59.5ms avg: 46.0ms
Page   5: min: 41.6ms max: 77.4ms avg: 49.1ms
```

Maybe also look at #594 