### PR TITLE
Optimize magnet generation

### DIFF
--- a/nyaa/models.py
+++ b/nyaa/models.py
@@ -17,7 +17,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy_fulltext import FullText
 from sqlalchemy_utils import ChoiceType, EmailType, PasswordType
 
-from nyaa.extensions import cache, config, db
+from nyaa.extensions import config, db
 from nyaa.torrents import create_magnet
 
 app = flask.current_app
@@ -250,7 +250,6 @@ class TorrentBase(DeclarativeHelperBase):
         return self.info_hash.hex()
 
     @property
-    @cache.memoize(timeout=3600)
     def magnet_uri(self):
         return create_magnet(self)
 


### PR DESCRIPTION
```
with our trusty tool: caching!
```

Turns out the old cache.memoize wasn't doing much at all. Implement working caching for the magnet uri generation.

Bench
```
Before patch
Page   1: min: 59.0ms max: 72.9ms avg: 67.1ms
Page   2: min: 56.2ms max: 97.6ms avg: 66.1ms
Page   3: min: 60.1ms max: 92.4ms avg: 69.3ms
Page   4: min: 59.9ms max: 88.0ms avg: 68.8ms
Page   5: min: 60.1ms max: 90.9ms avg: 67.1ms

With patch
Page   1: min: 42.0ms max: 57.5ms avg: 50.1ms
Page   2: min: 44.9ms max: 61.4ms avg: 50.7ms
Page   3: min: 43.9ms max: 64.1ms avg: 50.1ms
Page   4: min: 45.9ms max: 62.2ms avg: 52.4ms
Page   5: min: 45.6ms max: 76.2ms avg: 53.4ms

With patch + baked + count cache
Page   1: min: 27.3ms max: 36.6ms avg: 30.0ms
Page   2: min: 25.8ms max: 40.0ms avg: 29.4ms
Page   3: min: 25.3ms max: 40.9ms avg: 31.9ms
Page   4: min: 25.1ms max: 43.4ms avg: 30.8ms
Page   5: min: 25.5ms max: 63.2ms avg: 33.1ms
```

Yeah look and drool.