### PR TITLE
Allow filtering by multiple users

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -156,6 +156,13 @@ RESULTS_PER_PAGE = 75
 # How many pages we'll return at most
 MAX_PAGES = 100
 
+# How long and how many entries to cache for count queries
+COUNT_CACHE_SIZE = 256
+COUNT_CACHE_DURATION = 30
+
+# Use baked queries for database search
+USE_BAKED_SEARCH = False
+
 # Use better searching with ElasticSearch
 # See README.MD on setup!
 USE_ELASTIC_SEARCH = False

--- a/nyaa/templates/layout.html
+++ b/nyaa/templates/layout.html
@@ -9,7 +9,7 @@
 		<link rel="shortcut icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
 		<link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
 		<link rel="mask-icon" href="{{ url_for('static', filename='pinned-tab.svg') }}" color="#3582F7">
-		<link rel="alternate" type="application/rss+xml" href="{% if rss_filter %}{{ url_for('main.home', page='rss', _external=True, **rss_filter) }}{% else %}{{ url_for('main.home', page='rss', _external=True) }}{% endif %}" />
+		<link rel="alternate" type="application/rss+xml" href="{% if rss_filter %}{{ url_for('main.home', page='rss', _external=True) + '&' + rss_filter }}{% else %}{{ url_for('main.home', page='rss', _external=True) }}{% endif %}" />
 
 		<meta property="og:site_name" content="{{ config.SITE_NAME }}">
 		<meta property="og:title" content="{{ self.title() }}">
@@ -93,7 +93,7 @@
 								<li {% if request.path == url_for('site.trusted') %}class="active"{% endif %}><a href="{{ url_for('site.trusted') }}">Trusted</a></li>
 							</ul>
 						</li>
-						<li><a href="{% if rss_filter %}{{ url_for('main.home', page='rss', **rss_filter) }}{% else %}{{ url_for('main.home', page='rss') }}{% endif %}">RSS</a></li>
+						<li><a href="{% if rss_filter %}{{ url_for('main.home', page='rss') + '&' + rss_filter }}{% else %}{{ url_for('main.home', page='rss') }}{% endif %}">RSS</a></li>
 						{% if config.SITE_FLAVOR == 'nyaa' %}
 						<li><a href="//{{ config.EXTERNAL_URLS['fap'] }}">Fap</a></li>
 						{% elif config.SITE_FLAVOR == 'sukebei' %}

--- a/nyaa/views/main.py
+++ b/nyaa/views/main.py
@@ -10,7 +10,7 @@ from flask_paginate import Pagination
 from nyaa import models
 from nyaa.extensions import db
 from nyaa.search import (DEFAULT_MAX_SEARCH_RESULT, DEFAULT_PER_PAGE, SERACH_PAGINATE_DISPLAY_MSG,
-                         _generate_query_string, search_db, search_elastic)
+                         _generate_query_string, search_db, search_db_baked, search_elastic)
 from nyaa.utils import chain_get
 from nyaa.views.account import logout
 
@@ -186,7 +186,11 @@ def home(rss):
         else:  # Otherwise, use db search for everything
             query_args['term'] = search_term or ''
 
-        query = search_db(**query_args)
+        if app.config['USE_BAKED_SEARCH']:
+            query = search_db_baked(**query_args)
+        else:
+            query = search_db(**query_args)
+
         if render_as_rss:
             return render_rss('Home', query, use_elastic=False, magnet_links=use_magnet_links)
         else:

--- a/nyaa/views/users.py
+++ b/nyaa/views/users.py
@@ -12,7 +12,7 @@ from itsdangerous import BadSignature, URLSafeSerializer
 from nyaa import forms, models
 from nyaa.extensions import db
 from nyaa.search import (DEFAULT_MAX_SEARCH_RESULT, DEFAULT_PER_PAGE, SERACH_PAGINATE_DISPLAY_MSG,
-                         _generate_query_string, search_db, search_elastic)
+                         _generate_query_string, search_db, search_db_baked, search_elastic)
 from nyaa.utils import admin_only, chain_get, sha1_hash
 
 app = flask.current_app
@@ -185,7 +185,10 @@ def view_user(user_name):
             query_args['term'] = ''
         else:
             query_args['term'] = search_term or ''
-        query = search_db(**query_args)
+        if app.config['USE_BAKED_SEARCH']:
+            query = search_db_baked(**query_args)
+        else:
+            query = search_db(**query_args)
         return flask.render_template('user.html',
                                      use_elastic=False,
                                      torrent_query=query,

--- a/nyaa/views/users.py
+++ b/nyaa/views/users.py
@@ -130,7 +130,7 @@ def view_user(user_name):
 
     query_args = {
         'term': search_term or '',
-        'user': user.id,
+        'user_ids': (user.id,),  # Tuple!
         'sort': sort_key or 'id',
         'order': sort_order or 'desc',
         'category': category or '0_0',
@@ -146,7 +146,7 @@ def view_user(user_name):
             query_args['admin'] = True
 
     # Use elastic search for term searching
-    rss_query_string = _generate_query_string(search_term, category, quality_filter, user_name)
+    rss_query_string = _generate_query_string(search_term, category, quality_filter, [user_name])
     use_elastic = app.config.get('USE_ELASTIC_SEARCH')
     if use_elastic and search_term:
         query_args['term'] = search_term


### PR DESCRIPTION
⚠️ Merge after #592 ⚠️ 

```
...by repeating &u=user in the GET parameters.
No UX for this yet.
Reworks the RSS URL generator to fit with duplicated keys.
```

Sort of tested but could use a sharp look at.
```py
same_user = False
if logged_in_user:
    same_user = len(user_ids) == 1 and logged_in_user.id in user_ids
```
should replicate the previous functionality well enough.
