### PR TITLE
Support webtorrent protocol by adding webtorrent capable trackers

### DIFF
--- a/trackers.txt
+++ b/trackers.txt
@@ -5,3 +5,5 @@ udp://open.stealth.si:80/announce
 udp://tracker.opentrackr.org:1337/announce
 udp://tracker.coppersurfer.tk:6969/announce
 udp://exodus.desync.com:6969/announce
+wss://tracker.openwebtorrent.com
+wss://tracker.btorrent.xyz


### PR DESCRIPTION
fix https://github.com/nyaadevs/nyaa/issues/621

This change add two of the recommended webtorrent trackers `https://openwebtorrent.com/` &`https://btorrent.xyz/`

The WebTorrent protocol is quite widely supported amongst popular webtorrent clients so this will enable peers to seed to browser clients that only support webtorrent peers.