### PR TITLE
Support websocket clients by adding a websocket tracker

### DIFF
--- a/trackers.txt
+++ b/trackers.txt
@@ -5,3 +5,4 @@ udp://open.stealth.si:80/announce
 udp://tracker.opentrackr.org:1337/announce
 udp://tracker.coppersurfer.tk:6969/announce
 udp://exodus.desync.com:6969/announce
+wss://tracker.openwebtorrent.com


### PR DESCRIPTION
Nyaa's lack of ws trackers makes downloading torrents with WebTorrent close to impossible, the simplest fix is adding a 3rd party tracker. OpenWebTorrent is the only tracker that stood the test of time, being up for almost 5 years, it's also [open source](https://github.com/OpenWebTorrent/openwebtorrent-tracker).