### PR TITLE
Allow cross origin access for RSS

### DIFF
--- a/nyaa/views/main.py
+++ b/nyaa/views/main.py
@@ -218,4 +218,6 @@ def render_rss(label, query, use_elastic, magnet_links=False):
     response.headers['Content-Type'] = 'application/xml'
     # Cache for an hour
     response.headers['Cache-Control'] = 'max-age={}'.format(1 * 5 * 60)
+    # Allow cross origin access
+    response.headers['Access-Control-Allow-Origin'] = '*'
     return response

--- a/nyaa/views/torrents.py
+++ b/nyaa/views/torrents.py
@@ -332,6 +332,8 @@ def download_torrent(torrent_id):
     resp.headers['Content-Type'] = 'application/x-bittorrent'
     resp.headers['Content-Disposition'] = disposition
     resp.headers['Content-Length'] = torrent_file_size
+    # Allow cross origin access
+    resp.headers['Access-Control-Allow-Origin'] = '*'
     return resp
 
 


### PR DESCRIPTION
Allows browser-based code to access the RSS feed without browser interrupting the connection.

Figured this change is very needed as an RSS feed is fairly useless if people that want to use it can't access it from their code, for example if they have a fully front-end application that runs for the most part in the browser. Without this change, the browser would throw an error during the request as the RSS feed doesn't have the header ``Access-Control-Allow-Origin: *``. This PR will fix that issue.